### PR TITLE
Refresh design system and landing layout

### DIFF
--- a/DESIGN_OVERVIEW.md
+++ b/DESIGN_OVERVIEW.md
@@ -1,0 +1,36 @@
+# Design Overview
+
+Dieses kurze Dokument fasst die wichtigsten Designanpassungen zusammen und zeigt, wo sich die zentralen Werte befinden.
+
+## Tokens & Grundlagen
+- Globale Design Tokens liegen in [`app/tokens.css`](app/tokens.css).
+- Die wichtigsten Variablen:
+  - `--color-bg`, `--color-surface`, `--color-fg`, `--color-muted`
+  - `--color-accent`, `--color-accent-strong`, `--color-accent-soft`
+  - `--radius`, `--shadow-soft`, `--container-w`
+- Dark-Mode-Werte sind in `html.dark` hinterlegt und können durch Hinzufügen der Klasse `dark` auf dem `<html>`-Element aktiviert werden.
+
+## Globale Styles
+- Der neue Grundstil wird in [`app/globals.css`](app/globals.css) gepflegt. Dort finden sich die Typografie-Skala, Container-Hilfsklassen (`.layout-container`, `.section`, `.surface-card`, `.btn`, etc.) und Farbharmonisierung für bestehende Utility-Klassen.
+- Buttons verwenden die Klassen `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-ghost`.
+- Karten und Flächen nutzen `.surface-card` bzw. `.surface-muted`.
+- Die Navigationslinks erhalten automatische Hervorhebung über `.nav-link`.
+
+## Komponenten
+- Wichtige Komponenten mit überarbeiteten Styles:
+  - Navigation & Footer (`app/[locale]/layout.tsx`, `app/components/NavLink.tsx`, `app/components/Footer.tsx`)
+  - Startseite (`app/[locale]/page.tsx`) inkl. neuer Karten- und Statistikoptik
+  - Address Checker & Risikoauswertung (`app/components/AddressChecker.tsx`, `app/components/RiskAssessment.tsx`, `app/components/POIList.tsx`, `app/components/AnimatedStats.tsx`)
+  - FAQ (`app/[locale]/faq/FAQPageClient.tsx`)
+  - Dokumentkarten (`app/components/Documents/DocumentCard.tsx`)
+- Bestehende Utility-Klassen (z. B. `bg-blue-50`) werden über globale Regeln auf die neue Farbwelt gemappt.
+
+## Layout & Abstände
+- Containerbreite: `--container-w` (derzeit 72rem). Verwenden Sie `.layout-container` und `.section` für konsistente Seitenabstände.
+- Standardabstände basieren auf einem 8pt-Raster; zusätzliche Hilfsklassen (`.section-tight`, `.feature-grid`) helfen beim Layout.
+
+## Fokus & Motion
+- Fokuszustände sind global definiert (sichtbarer Fokus-Ring, WCAG-konform).
+- Motion reduziert sich automatisch über `prefers-reduced-motion`.
+
+Für Fragen oder neue Komponenten empfiehlt es sich, bestehende Tokens und Hilfsklassen wiederzuverwenden, um die Konsistenz des Designs sicherzustellen.

--- a/app/[locale]/adressen-check/page.tsx
+++ b/app/[locale]/adressen-check/page.tsx
@@ -5,26 +5,16 @@ export default async function AddressCheckPage() {
   const t = await getTranslations('addressChecker');
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-blue-50 to-gray-100">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 shadow-sm">
-        <div className="container mx-auto px-4 py-12 max-w-6xl">
-          <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4 bg-gradient-to-r from-blue-600 to-blue-800 bg-clip-text text-transparent">
-              {t('title')}
-            </h1>
-            <p className="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto mb-2">
-              {t('subtitle')}
-            </p>
-            <p className="text-base text-gray-500 max-w-3xl mx-auto">
-              {t('description')}
-            </p>
-          </div>
-        </div>
-      </div>
+    <div className="section">
+      <div className="layout-container space-y-12">
+        <header className="text-center space-y-4">
+          <h1 className="text-balance">{t('title')}</h1>
+          <p className="mx-auto text-lg md:text-xl text-[color:var(--color-muted)] max-w-3xl">{t('subtitle')}</p>
+          <p className="mx-auto text-sm md:text-base" style={{ color: 'color-mix(in srgb, var(--color-muted) 80%, white 20%)', maxWidth: '60ch' }}>
+            {t('description')}
+          </p>
+        </header>
 
-      {/* Main Content */}
-      <div className="container mx-auto px-4 py-8 max-w-7xl">
         <AddressChecker />
       </div>
     </div>

--- a/app/[locale]/dokumente/page.tsx
+++ b/app/[locale]/dokumente/page.tsx
@@ -22,8 +22,7 @@ import {
   Wrench,
   FolderOpen,
   Users,
-  CheckSquare,
-  RefreshCw
+  CheckSquare
 } from 'lucide-react';
 import { defaultLocale } from '@/i18n';
 

--- a/app/[locale]/faq/FAQPageClient.tsx
+++ b/app/[locale]/faq/FAQPageClient.tsx
@@ -46,31 +46,22 @@ export default function FAQPageClient({ locale }: FAQPageClientProps) {
         suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: faqSchemaJson }}
       />
-      <div className="min-h-screen bg-gradient-to-br from-gray-50 via-blue-50 to-gray-100 py-12">
-        <div className="max-w-4xl mx-auto px-4">
+      <div className="section">
+        <div className="layout-container max-w-4xl mx-auto space-y-10">
           {/* Header */}
-          <div className="text-center mb-12">
-            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4 bg-gradient-to-r from-blue-600 to-blue-800 bg-clip-text text-transparent">
-              {t('title')}
-            </h1>
-            <p className="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto">{t('subtitle')}</p>
+          <div className="text-center space-y-4">
+            <h1 className="text-balance">{t('title')}</h1>
+            <p className="mx-auto text-lg md:text-xl text-[color:var(--color-muted)] max-w-3xl">{t('subtitle')}</p>
           </div>
 
           {/* FAQ Accordion */}
           <div className="space-y-4">
-            {questions.map((q, index) => (
-              <div
-                key={q}
-                className="bg-white rounded-xl shadow-md overflow-hidden border border-gray-100 hover:shadow-lg transition-all duration-300"
-                style={{ animationDelay: `${index * 0.05}s` }}
-              >
-                <button
-                  onClick={() => toggleQuestion(q)}
-                  className="w-full text-left p-6 flex items-center justify-between hover:bg-gray-50 transition-colors"
-                >
-                  <span className="text-lg font-semibold text-gray-900 pr-4">{t(`questions.${q}.question`)}</span>
+            {questions.map((q) => (
+              <div key={q} className="faq-item" style={{ animation: 'fade-up 0.4s ease forwards' }}>
+                <button onClick={() => toggleQuestion(q)} className="faq-trigger">
+                  <span className="flex-1 text-left text-balance">{t(`questions.${q}.question`)}</span>
                   <svg
-                    className={`w-6 h-6 text-blue-600 flex-shrink-0 transition-transform duration-300 ${openQuestion === q ? 'rotate-180' : ''}`}
+                    className={`w-5 h-5 text-[color:var(--color-accent)] transition-transform ${openQuestion === q ? 'rotate-180' : ''}`}
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -79,25 +70,26 @@ export default function FAQPageClient({ locale }: FAQPageClientProps) {
                   </svg>
                 </button>
                 <div
-                  className={`transition-all duration-300 ease-in-out ${
-                    openQuestion === q ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
-                  }`}
+                  className="overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
+                  style={{
+                    maxHeight: openQuestion === q ? '480px' : '0px',
+                    opacity: openQuestion === q ? 1 : 0,
+                  }}
                 >
-                  <div className="p-6 pt-0 text-gray-700 leading-relaxed border-t border-gray-100">
-                    {t(`questions.${q}.answer`)}
-                  </div>
+                  <div className="faq-content">{t(`questions.${q}.answer`)}</div>
                 </div>
               </div>
             ))}
           </div>
 
           {/* CTA Section */}
-          <div className="mt-12 bg-gradient-to-r from-blue-600 to-blue-700 rounded-2xl p-8 text-center text-white">
-            <h2 className="text-2xl md:text-3xl font-bold mb-4">{t('cta.title')}</h2>
-            <p className="text-lg mb-6 opacity-90">{t('cta.description')}</p>
+          <div className="surface-card text-center space-y-4" style={{ background: 'var(--color-surface-muted)' }}>
+            <h2 className="text-2xl md:text-3xl font-semibold text-[color:var(--color-fg)]">{t('cta.title')}</h2>
+            <p className="text-lg text-[color:var(--color-muted)]">{t('cta.description')}</p>
             <Link
               href={`/${locale}/check`}
-              className="inline-block bg-white text-blue-600 px-8 py-4 rounded-xl font-bold hover:bg-gray-100 transition-colors shadow-lg"
+              className="btn btn-primary inline-flex"
+              style={{ justifyContent: 'center' }}
             >
               {t('cta.button')}
             </Link>

--- a/app/[locale]/formular-assistent/page.tsx
+++ b/app/[locale]/formular-assistent/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 
 export default function FormularAssistentPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 py-12">
-      <div className="container mx-auto px-4">
+    <div className="section">
+      <div className="layout-container">
         <FormularWizard />
       </div>
     </div>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { locales, type Locale } from '@/i18n'
 import Footer from '../components/Footer'
 import LanguageBanner from '../components/LanguageBanner'
 import LanguageSwitcher from '../components/LanguageSwitcher'
+import NavLink from '../components/NavLink'
 import {
   FALLBACK_METADATA,
   SITE_URL,
@@ -115,7 +116,7 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale}>
-      <body className="bg-gradient-to-br from-gray-50 via-blue-50 to-gray-100">
+      <body className="page-shell">
         <script
           type="application/ld+json"
           suppressHydrationWarning
@@ -128,53 +129,27 @@ export default async function LocaleLayout({
         />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <LanguageBanner />
-          <nav className="bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-40 shadow-sm">
-            <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
-              <Link href={`/${locale}`} className="flex items-center gap-3 group cursor-pointer">
-                <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-blue-700 rounded-lg flex items-center justify-center shadow-md group-hover:scale-110 transition-transform">
+          <nav className="site-nav">
+            <div className="layout-container py-4 flex items-center justify-between gap-6">
+              <Link href={`/${locale}`} className="flex items-center gap-3" aria-label="Betriebsanlagen Check Startseite">
+                <span className="stat-icon !w-11 !h-11 rounded-full">
                   <svg
-                    className="w-6 h-6 text-white"
+                    className="w-6 h-6"
                     fill="none"
                     stroke="currentColor"
+                    strokeWidth={2}
                     viewBox="0 0 24 24"
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
-                </div>
-                <h1 className="text-xl font-bold text-gray-800 group-hover:text-blue-600 transition-colors">
-                  Betriebsanlagen Check
-                </h1>
+                </span>
+                <span className="text-lg font-semibold tracking-tight text-balance">Betriebsanlagen Check</span>
               </Link>
-              <div className="flex items-center gap-6">
-                <Link
-                  href={`/${locale}/adressen-check`}
-                  className="hidden md:block text-gray-700 hover:text-blue-600 transition-colors font-medium"
-                >
-                  Adressen-Check
-                </Link>
-                <Link
-                  href={`/${locale}/formular-assistent`}
-                  className="hidden md:block text-gray-700 hover:text-blue-600 transition-colors font-medium"
-                >
-                  Formular-Assistent
-                </Link>
-                <Link
-                  href={`/${locale}/dokumente`}
-                  className="hidden md:block text-gray-700 hover:text-blue-600 transition-colors font-medium"
-                >
-                  Dokumente
-                </Link>
-                <Link
-                  href={`/${locale}/faq`}
-                  className="hidden md:block text-gray-700 hover:text-blue-600 transition-colors font-medium"
-                >
-                  FAQ
-                </Link>
+              <div className="hidden md:flex items-center gap-4">
+                <NavLink href={`/${locale}/adressen-check`}>Adressen-Check</NavLink>
+                <NavLink href={`/${locale}/formular-assistent`}>Formular-Assistent</NavLink>
+                <NavLink href={`/${locale}/dokumente`}>Dokumente</NavLink>
+                <NavLink href={`/${locale}/faq`}>FAQ</NavLink>
                 <LanguageSwitcher />
               </div>
             </div>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -6,9 +6,7 @@ import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import AnimatedStats from "../components/AnimatedStats";
-import { useEffect, useState } from "react";
 import { defaultLocale } from "@/i18n";
-import { HeroCtas, type SupportedLocale } from "./_components/hero-ctas";
 import { CheckCircle2, FileText, Zap, Languages, Shield, ArrowRight, Sparkles } from "lucide-react";
 
 // Displays the localized homepage with locale-aware navigation targets.
@@ -18,10 +16,6 @@ export default function Home() {
   const params = useParams<{ locale: string }>();
   const paramLocale = params?.locale;
   const activeLocale = Array.isArray(paramLocale) ? paramLocale[0] : paramLocale ?? defaultLocale;
-  const isSupportedLocale = (value: string | undefined): value is SupportedLocale =>
-    value === "de" || value === "en";
-  const heroLocale = isSupportedLocale(activeLocale) ? activeLocale : "de";
-  const [scrollY, setScrollY] = useState(0);
 
   // QA Page schema for AI search and Google Featured Snippets
   const qaSchema = {
@@ -63,15 +57,6 @@ export default function Home() {
     ]
   };
 
-  useEffect(() => {
-    const handleScroll = () => {
-      setScrollY(window.scrollY);
-    };
-
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
   return (
     <>
       {/* QA Schema for AI Search and Featured Snippets */}
@@ -81,251 +66,167 @@ export default function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(qaSchema) }}
       />
 
-      <main className="min-h-screen bg-gradient-to-br from-gray-50 via-blue-50 to-gray-100 relative overflow-hidden">
-        {/* Animated background shapes */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-10 w-72 h-72 bg-blue-200/20 rounded-full blur-3xl animate-float"></div>
-        <div className="absolute bottom-20 right-10 w-96 h-96 bg-purple-200/20 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s', animationDuration: '4s' }}></div>
-        <div className="absolute top-1/2 left-1/2 w-80 h-80 bg-green-200/10 rounded-full blur-3xl animate-float" style={{ animationDelay: '1s', animationDuration: '5s' }}></div>
-      </div>
+      <main className="min-h-screen">
+        <section className="section">
+          <div className="layout-container flex flex-col gap-16">
+            <div className="mx-auto max-w-3xl text-center space-y-6">
+              <h1 className="text-balance">{t("title")}</h1>
+              <p className="text-lg md:text-xl text-[color:var(--color-muted)]">{t("subtitle")}</p>
+            </div>
 
-      <div className="max-w-6xl mx-auto px-4 py-16 relative z-10">
-        {/* Hero Section */}
-        <div
-          className="text-center mb-16 animate-fadeIn"
-          style={{ transform: `translateY(${scrollY * 0.3}px)`, opacity: Math.max(0, 1 - scrollY / 500) }}
-        >
-          <h1 className="text-5xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
-            <span className="bg-gradient-to-r from-blue-600 to-blue-800 bg-clip-text text-transparent">
-              {t("title")}
-            </span>
-          </h1>
-          <p className="text-xl md:text-2xl text-gray-600 max-w-3xl mx-auto font-normal leading-relaxed">
-            {t("subtitle")}
-          </p>
-        </div>
-
-        {/* Primary actions */}
-        <div className="grid md:grid-cols-2 gap-8 mb-16">
-          {/* Card 1: Check if permit is needed */}
-          <div className="group card-lift bg-white rounded-2xl overflow-hidden border border-gray-200 hover:border-blue-300 relative transition-all duration-200" style={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}>
-            <div className="h-1.5 bg-gradient-to-r from-blue-600 to-blue-700"></div>
-            <div className="p-8">
-              <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center mb-6 group-hover:scale-105 transition-all duration-200" style={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}>
-                <CheckCircle2 className="w-8 h-8 text-white" strokeWidth={2.5} />
-              </div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                {t("card1Title")}
-              </h2>
-              <p className="text-gray-600 mb-8 leading-relaxed font-normal">
-                {t("card1Description")}
-              </p>
-              <Link
-                href={`/${activeLocale}/check`}
-                className="button-shine button-click inline-flex items-center gap-2 w-full justify-center bg-gradient-to-r from-blue-600 to-blue-700 text-white py-4 px-6 rounded-xl font-semibold hover:from-blue-700 hover:to-blue-800 transition-all duration-200"
-                style={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}
+            <div className="feature-grid">
+              <div
+                className="surface-card h-full flex flex-col gap-6 text-left"
+                style={{ borderTop: '4px solid var(--color-accent)' }}
               >
-                {t("card1Button")}
-                <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-              </Link>
-            </div>
-          </div>
-
-          {/* Card 2: Documents and process */}
-          <div className="group card-lift bg-white rounded-2xl overflow-hidden border border-gray-200 hover:border-[#FF6B35] relative transition-all duration-200" style={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}>
-            <div className="h-1.5 bg-gradient-to-r from-[#FF6B35] to-[#e55a28]"></div>
-            <div className="p-8">
-              <div className="w-16 h-16 bg-gradient-to-br from-[#FF6B35] to-[#e55a28] rounded-xl flex items-center justify-center mb-6 group-hover:scale-105 transition-all duration-200" style={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}>
-                <FileText className="w-8 h-8 text-white" strokeWidth={2.5} />
+                <span className="stat-icon !w-14 !h-14">
+                  <CheckCircle2 className="w-7 h-7" strokeWidth={2} />
+                </span>
+                <div className="space-y-4">
+                  <h2 className="text-2xl text-[color:var(--color-fg)]">{t("card1Title")}</h2>
+                  <p>{t("card1Description")}</p>
+                </div>
+                <Link
+                  href={`/${activeLocale}/check`}
+                  className="btn btn-primary w-full"
+                  style={{ justifyContent: 'space-between' }}
+                >
+                  {t("card1Button")}
+                  <ArrowRight className="w-5 h-5" />
+                </Link>
               </div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                {t("card2Title")}
-              </h2>
-              <p className="text-gray-600 mb-8 leading-relaxed font-normal">
-                {t("card2Description")}
-              </p>
-              <Link
-                href={`/${activeLocale}/dokumente`}
-                className="button-shine button-click inline-flex items-center gap-2 w-full justify-center bg-gradient-to-r from-[#FF6B35] to-[#e55a28] text-white py-4 px-6 rounded-xl font-semibold hover:from-[#e55a28] hover:to-[#cc4d1f] transition-all duration-200"
-                style={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }}
+
+              <div
+                className="surface-card h-full flex flex-col gap-6 text-left"
+                style={{ borderTop: '4px solid var(--color-warning)' }}
               >
-                {t("card2Button")}
-                <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-              </Link>
-            </div>
-          </div>
-
-        </div>
-
-        {/* Animated Stats */}
-        <div className="mb-16">
-          <AnimatedStats
-            stats={[
-              {
-                value: 8,
-                suffix: "",
-                label: t("stats.languages"),
-                icon: (
-                  <Languages className="w-7 h-7 text-white" strokeWidth={2} />
-                ),
-              },
-              {
-                value: 2,
-                suffix: " Min",
-                label: t("stats.time"),
-                icon: (
-                  <Zap className="w-7 h-7 text-white" strokeWidth={2} />
-                ),
-              },
-              {
-                value: 100,
-                suffix: "%",
-                label: t("stats.free"),
-                icon: (
-                  <Shield className="w-7 h-7 text-white" strokeWidth={2} />
-                ),
-              },
-            ]}
-          />
-        </div>
-
-        {/* SEO Content Section */}
-        <div className="mt-20 space-y-12">
-          {/* Main SEO Heading */}
-          <div className="text-center animate-fadeIn">
-            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-              {t("seo.heading")}
-            </h2>
-            <p className="text-lg text-gray-600 max-w-4xl mx-auto leading-relaxed font-normal">
-              {t("seo.intro")}
-            </p>
-          </div>
-
-          {/* Features Grid */}
-          <div className="grid md:grid-cols-3 gap-8">
-            <div className="card-lift bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 transition-all duration-200" style={{ boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)' }}>
-              <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-                <Zap className="w-6 h-6 text-blue-600" strokeWidth={2} />
+                <span
+                  className="stat-icon !w-14 !h-14"
+                  style={{ background: 'rgba(179, 90, 31, 0.15)', color: 'var(--color-warning)' }}
+                >
+                  <FileText className="w-7 h-7" strokeWidth={2} />
+                </span>
+                <div className="space-y-4">
+                  <h2 className="text-2xl text-[color:var(--color-fg)]">{t("card2Title")}</h2>
+                  <p>{t("card2Description")}</p>
+                </div>
+                <Link
+                  href={`/${activeLocale}/dokumente`}
+                  className="btn btn-secondary w-full"
+                  style={{ justifyContent: 'space-between' }}
+                >
+                  {t("card2Button")}
+                  <ArrowRight className="w-5 h-5" />
+                </Link>
               </div>
-              <h3 className="text-xl font-bold text-gray-900 mb-3">
-                {t("seo.feature1Title")}
-              </h3>
-              <p className="text-gray-600 leading-relaxed font-normal">
-                {t("seo.feature1Text")}
-              </p>
             </div>
 
-            <div className="card-lift bg-white rounded-xl p-6 border border-gray-200 hover:border-[#22C55E] transition-all duration-200" style={{ boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)' }}>
-              <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mb-4">
-                <Languages className="w-6 h-6 text-green-600" strokeWidth={2} />
+            <div className="surface-muted border border-[color:var(--color-border)] rounded-[calc(var(--radius)+2px)] p-6 md:p-10">
+              <AnimatedStats
+                stats={[
+                  {
+                    value: 8,
+                    suffix: '',
+                    label: t("stats.languages"),
+                    icon: <Languages className="w-6 h-6" strokeWidth={2} />,
+                  },
+                  {
+                    value: 2,
+                    suffix: ' Min',
+                    label: t("stats.time"),
+                    icon: <Zap className="w-6 h-6" strokeWidth={2} />,
+                  },
+                  {
+                    value: 100,
+                    suffix: '%',
+                    label: t("stats.free"),
+                    icon: <Shield className="w-6 h-6" strokeWidth={2} />,
+                  },
+                ]}
+              />
+            </div>
+
+            <div className="space-y-14">
+              <div className="text-center space-y-4">
+                <h2>{t("seo.heading")}</h2>
+                <p className="mx-auto text-lg md:text-xl text-[color:var(--color-muted)] max-w-4xl">{t("seo.intro")}</p>
               </div>
-              <h3 className="text-xl font-bold text-gray-900 mb-3">
-                {t("seo.feature2Title")}
-              </h3>
-              <p className="text-gray-600 leading-relaxed font-normal">
-                {t("seo.feature2Text")}
-              </p>
-            </div>
 
-            <div className="card-lift bg-white rounded-xl p-6 border border-gray-200 hover:border-purple-300 transition-all duration-200" style={{ boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)' }}>
-              <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-                <Shield className="w-6 h-6 text-purple-600" strokeWidth={2} />
-              </div>
-              <h3 className="text-xl font-bold text-gray-900 mb-3">
-                {t("seo.feature3Title")}
-              </h3>
-              <p className="text-gray-600 leading-relaxed font-normal">
-                {t("seo.feature3Text")}
-              </p>
-            </div>
-          </div>
-
-          {/* Additional SEO Content */}
-          <div className="bg-gradient-to-r from-blue-50 to-blue-100/50 rounded-2xl p-8 md:p-10 border border-blue-200 animate-fadeIn">
-            <div className="flex items-start gap-4">
-              <div className="flex-shrink-0">
-                <div className="w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center">
-                  <Sparkles className="w-6 h-6 text-white" strokeWidth={2} />
+              <div className="feature-grid md:grid-cols-3">
+                <div className="surface-card h-full space-y-4">
+                  <span className="stat-icon">
+                    <Zap className="w-5 h-5" strokeWidth={2} />
+                  </span>
+                  <h3 className="text-xl text-[color:var(--color-fg)]">{t("seo.feature1Title")}</h3>
+                  <p>{t("seo.feature1Text")}</p>
+                </div>
+                <div className="surface-card h-full space-y-4">
+                  <span className="stat-icon">
+                    <Languages className="w-5 h-5" strokeWidth={2} />
+                  </span>
+                  <h3 className="text-xl text-[color:var(--color-fg)]">{t("seo.feature2Title")}</h3>
+                  <p>{t("seo.feature2Text")}</p>
+                </div>
+                <div className="surface-card h-full space-y-4">
+                  <span className="stat-icon">
+                    <Shield className="w-5 h-5" strokeWidth={2} />
+                  </span>
+                  <h3 className="text-xl text-[color:var(--color-fg)]">{t("seo.feature3Title")}</h3>
+                  <p>{t("seo.feature3Text")}</p>
                 </div>
               </div>
-              <div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-4">
-                  {t("seo.whyTitle")}
-                </h3>
-                <p className="text-gray-700 leading-relaxed text-lg font-normal">
-                  {t("seo.whyText")}
-                </p>
+
+              <div className="surface-card flex flex-col gap-6 md:flex-row md:items-start">
+                <span className="stat-icon !w-12 !h-12">
+                  <Sparkles className="w-5 h-5" strokeWidth={2} />
+                </span>
+                <div className="space-y-4">
+                  <h3 className="text-2xl text-[color:var(--color-fg)]">{t("seo.whyTitle")}</h3>
+                  <p className="text-lg text-[color:var(--color-muted)]">{t("seo.whyText")}</p>
+                </div>
+              </div>
+
+              <div className="space-y-10">
+                <div className="text-center space-y-4">
+                  <h2>{t("gruender.heading")}</h2>
+                  <p className="mx-auto text-lg md:text-xl text-[color:var(--color-muted)] max-w-4xl">{t("gruender.intro")}</p>
+                </div>
+                <div className="feature-grid md:grid-cols-2">
+                  <div className="surface-card space-y-3">
+                    <h3 className="text-xl text-[color:var(--color-fg)]">{t("gruender.question1")}</h3>
+                    <p>{t("gruender.answer1")}</p>
+                  </div>
+                  <div className="surface-card space-y-3">
+                    <h3 className="text-xl text-[color:var(--color-fg)]">{t("gruender.question2")}</h3>
+                    <p>{t("gruender.answer2")}</p>
+                  </div>
+                  <div className="surface-card space-y-3">
+                    <h3 className="text-xl text-[color:var(--color-fg)]">{t("gruender.question3")}</h3>
+                    <p>{t("gruender.answer3")}</p>
+                  </div>
+                  <div className="surface-card space-y-3">
+                    <h3 className="text-xl text-[color:var(--color-fg)]">{t("gruender.question4")}</h3>
+                    <p>{t("gruender.answer4")}</p>
+                  </div>
+                </div>
+                <div
+                  className="surface-card text-center flex flex-col gap-4 items-center"
+                  style={{ background: 'var(--color-accent)', color: '#fff', border: 'none', boxShadow: '0 28px 50px -28px rgba(12, 46, 54, 0.55)' }}
+                >
+                  <h3 className="text-2xl md:text-3xl font-semibold">{t("gruender.ctaTitle")}</h3>
+                  <p className="text-lg max-w-3xl text-white/85">{t("gruender.ctaText")}</p>
+                  <Link
+                    href={`/${activeLocale}/check`}
+                    className="btn btn-ghost"
+                    style={{ background: '#fff', color: 'var(--color-accent-strong)', borderColor: 'transparent' }}
+                  >
+                    {t("card1Button")}
+                  </Link>
+                </div>
               </div>
             </div>
           </div>
-
-          {/* Founders / Gründer Section - AI Search Optimized Q&A */}
-          <div className="mt-12 animate-fadeIn">
-            <div className="text-center mb-10">
-              <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-                {t("gruender.heading")}
-              </h2>
-              <p className="text-lg text-gray-600 max-w-4xl mx-auto leading-relaxed font-normal">
-                {t("gruender.intro")}
-              </p>
-            </div>
-
-            <div className="grid md:grid-cols-2 gap-6">
-              {/* Question 1 */}
-              <div className="bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 transition-all duration-200 shadow-sm hover:shadow-md">
-                <h3 className="text-xl font-bold text-gray-900 mb-3">
-                  {t("gruender.question1")}
-                </h3>
-                <p className="text-gray-700 leading-relaxed font-normal">
-                  {t("gruender.answer1")}
-                </p>
-              </div>
-
-              {/* Question 2 */}
-              <div className="bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 transition-all duration-200 shadow-sm hover:shadow-md">
-                <h3 className="text-xl font-bold text-gray-900 mb-3">
-                  {t("gruender.question2")}
-                </h3>
-                <p className="text-gray-700 leading-relaxed font-normal">
-                  {t("gruender.answer2")}
-                </p>
-              </div>
-
-              {/* Question 3 */}
-              <div className="bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 transition-all duration-200 shadow-sm hover:shadow-md">
-                <h3 className="text-xl font-bold text-gray-900 mb-3">
-                  {t("gruender.question3")}
-                </h3>
-                <p className="text-gray-700 leading-relaxed font-normal">
-                  {t("gruender.answer3")}
-                </p>
-              </div>
-
-              {/* Question 4 */}
-              <div className="bg-white rounded-xl p-6 border border-gray-200 hover:border-blue-300 transition-all duration-200 shadow-sm hover:shadow-md">
-                <h3 className="text-xl font-bold text-gray-900 mb-3">
-                  {t("gruender.question4")}
-                </h3>
-                <p className="text-gray-700 leading-relaxed font-normal">
-                  {t("gruender.answer4")}
-                </p>
-              </div>
-            </div>
-
-            {/* CTA for Founders */}
-            <div className="mt-8 bg-gradient-to-r from-green-600 to-green-700 rounded-2xl p-8 text-center text-white">
-              <h3 className="text-2xl md:text-3xl font-bold mb-4">{t("gruender.ctaTitle")}</h3>
-              <p className="text-lg mb-6 opacity-90">{t("gruender.ctaText")}</p>
-              <Link
-                href={`/${activeLocale}/check`}
-                className="inline-block bg-white text-green-600 px-8 py-4 rounded-xl font-bold hover:bg-gray-100 transition-colors shadow-lg"
-              >
-                {t("card1Button")}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
+        </section>
       </main>
     </>
   );

--- a/app/components/AddressChecker.tsx
+++ b/app/components/AddressChecker.tsx
@@ -72,7 +72,7 @@ export default function AddressChecker() {
       setNearbyPOIs(pois);
 
       // Risikobewertung durchführen
-      const assessment = analyzePOIs(pois, addressData);
+      const assessment = analyzePOIs(pois);
       setRiskAssessment(assessment);
     } catch (err) {
       console.error('POI loading error:', err);
@@ -108,31 +108,29 @@ export default function AddressChecker() {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Suchformular */}
-      <div className="bg-white rounded-xl shadow-md p-6 md:p-8">
+      <div className="surface-card space-y-4">
         <form onSubmit={handleSearch} className="space-y-4">
           <div>
-            <label htmlFor="address-input" className="block text-sm font-semibold text-gray-700 mb-2">
-              {t('search.label')}
-            </label>
-            <div className="flex gap-3">
-              <div className="flex-1 relative">
-                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <label htmlFor="address-input">{t('search.label')}</label>
+            <div className="flex flex-col gap-3 md:flex-row">
+              <div className="relative flex-1">
+                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
                 <input
                   id="address-input"
                   type="text"
                   value={address}
                   onChange={(e) => setAddress(e.target.value)}
                   placeholder={t('search.placeholder')}
-                  className="w-full pl-11 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all disabled:bg-gray-100 disabled:cursor-not-allowed"
+                  className="w-full pl-12 pr-4"
                   disabled={loading}
                 />
               </div>
               <button
                 type="submit"
                 disabled={loading || !address.trim()}
-                className="px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white rounded-lg font-semibold transition-colors flex items-center gap-2 disabled:cursor-not-allowed whitespace-nowrap"
+                className="btn btn-primary whitespace-nowrap"
               >
                 {loading ? (
                   <>
@@ -152,24 +150,31 @@ export default function AddressChecker() {
 
         {/* Fehleranzeige */}
         {error && (
-          <div className="mt-4 p-4 bg-red-50 border-l-4 border-red-500 rounded-r-lg">
-            <p className="text-red-800 font-medium">{error}</p>
+          <div
+            className="rounded-[var(--radius-sm)] border p-4"
+            style={{
+              borderColor: 'rgba(182, 61, 61, 0.45)',
+              background: 'color-mix(in srgb, var(--color-danger) 12%, white 88%)',
+            }}
+          >
+            <p style={{ color: 'var(--color-danger)', fontWeight: 600 }}>{error}</p>
           </div>
         )}
 
         {/* Mehrere Suchergebnisse */}
         {searchResults.length > 1 && (
-          <div className="mt-6">
-            <h3 className="font-bold text-gray-900 mb-3">{t('search.multipleResults')}</h3>
+          <div className="space-y-3">
+            <h3 className="text-lg font-semibold text-[color:var(--color-fg)]">{t('search.multipleResults')}</h3>
             <ul className="space-y-2">
               {searchResults.map((result, index) => (
                 <li key={index}>
                   <button
                     onClick={() => handleSelectAddress(result)}
-                    className="w-full text-left p-4 border-2 border-gray-200 hover:border-blue-500 hover:bg-blue-50 rounded-lg transition-all"
+                    className="w-full text-left rounded-[var(--radius-sm)] border border-[color:var(--color-border)] px-4 py-3 transition hover:border-[color:var(--color-accent)] hover:bg-[color:var(--color-accent-soft)] focus:outline-none"
+                    style={{ background: 'var(--color-surface)' }}
                   >
-                    <div className="font-medium text-gray-900">{result.fullAddress}</div>
-                    <div className="text-sm text-gray-600">
+                    <div className="font-medium text-[color:var(--color-fg)]">{result.fullAddress}</div>
+                    <div className="text-sm text-[color:var(--color-muted)]">
                       {result.postalCode} {result.district}
                     </div>
                   </button>
@@ -184,34 +189,27 @@ export default function AddressChecker() {
       {selectedAddress && !loading && (
         <>
           {/* Ausgewählte Adresse */}
-          <div className="bg-white rounded-xl shadow-md p-6">
-            <div className="flex items-start justify-between">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 mb-1">
+          <div className="surface-card space-y-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-1">
+                <h2 className="text-xl font-semibold text-[color:var(--color-fg)]">
                   {selectedAddress.fullAddress}
                 </h2>
-                <p className="text-gray-600">
+                <p className="text-[color:var(--color-muted)]">
                   {selectedAddress.postalCode} Wien, {selectedAddress.district}. Bezirk
                 </p>
               </div>
-              <button
-                onClick={handleReset}
-                className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg font-medium transition-colors"
-              >
+              <button onClick={handleReset} className="btn btn-ghost whitespace-nowrap">
                 {t('actions.newCheck')}
               </button>
             </div>
           </div>
 
           {/* Radius-Einstellung */}
-          <div className="bg-white rounded-xl shadow-md p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-bold text-gray-900">
-                Suchradius anpassen
-              </h3>
-              <span className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full font-semibold text-sm">
-                {searchRadius}m
-              </span>
+          <div className="surface-card space-y-5">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-[color:var(--color-fg)]">Suchradius anpassen</h3>
+              <span className="badge badge-accent text-sm font-semibold">{searchRadius}m</span>
             </div>
 
             <div className="space-y-4">
@@ -222,10 +220,11 @@ export default function AddressChecker() {
                 step="50"
                 value={searchRadius}
                 onChange={(e) => handleRadiusChange(Number(e.target.value))}
-                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                className="w-full"
+                style={{ accentColor: 'var(--color-accent)' }}
               />
 
-              <div className="flex justify-between text-xs text-gray-600">
+              <div className="flex justify-between text-xs text-[color:var(--color-muted)]">
                 <span>100m</span>
                 <span>200m</span>
                 <span>300m</span>
@@ -233,47 +232,40 @@ export default function AddressChecker() {
                 <span>500m</span>
               </div>
 
-              <p className="text-sm text-gray-600">
-                Zeigt kritische Einrichtungen im Umkreis von {searchRadius} Metern an.
-                Größerer Radius = mehr POIs, umfassendere Analyse.
+              <p className="text-sm text-[color:var(--color-muted)]">
+                Zeigt kritische Einrichtungen im Umkreis von {searchRadius} Metern an. Größerer Radius = mehr POIs, umfassendere Analyse.
               </p>
             </div>
           </div>
 
           {/* POI-Liste und Karte Grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             {/* POI-Liste */}
-            <div className="bg-white rounded-xl shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                {t('pois.title')}
-              </h2>
+            <div className="surface-card space-y-4">
+              <h2 className="text-2xl font-semibold text-[color:var(--color-fg)]">{t('pois.title')}</h2>
               <POIList pois={nearbyPOIs} />
             </div>
 
             {/* Karte */}
-            <div className="bg-white rounded-xl shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                {t('map.title')}
-              </h2>
+            <div className="surface-card space-y-4">
+              <h2 className="text-2xl font-semibold text-[color:var(--color-fg)]">{t('map.title')}</h2>
               <ViennaGISMap address={selectedAddress} pois={nearbyPOIs} />
-              <p className="text-xs text-gray-500 mt-2">
+              <p className="text-xs" style={{ color: 'color-mix(in srgb, var(--color-muted) 70%, white 30%)' }}>
                 {t('map.attribution')}
               </p>
             </div>
           </div>
 
           {/* Risikobewertung */}
-          {riskAssessment && (
-            <RiskAssessment assessment={riskAssessment} address={selectedAddress} />
-          )}
+          {riskAssessment && <RiskAssessment assessment={riskAssessment} />}
         </>
       )}
 
       {/* Loading State */}
       {selectedAddress && loading && (
-        <div className="bg-white rounded-xl shadow-md p-12 text-center">
-          <Loader2 className="w-12 h-12 animate-spin mx-auto mb-4 text-blue-600" />
-          <p className="text-gray-600">Analysiere Umgebung...</p>
+        <div className="surface-card p-12 text-center flex flex-col items-center gap-4">
+          <Loader2 className="w-12 h-12 animate-spin text-[color:var(--color-accent)]" />
+          <p className="text-[color:var(--color-muted)]">Analysiere Umgebung...</p>
         </div>
       )}
     </div>

--- a/app/components/AddressChecker.tsx
+++ b/app/components/AddressChecker.tsx
@@ -116,14 +116,14 @@ export default function AddressChecker() {
             <label htmlFor="address-input">{t('search.label')}</label>
             <div className="flex flex-col gap-3 md:flex-row">
               <div className="relative flex-1">
-                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
+                <MapPin className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
                 <input
                   id="address-input"
                   type="text"
                   value={address}
                   onChange={(e) => setAddress(e.target.value)}
                   placeholder={t('search.placeholder')}
-                  className="w-full pl-12 pr-4"
+                  className="w-full input-with-icon"
                   disabled={loading}
                 />
               </div>

--- a/app/components/AnimatedStats.tsx
+++ b/app/components/AnimatedStats.tsx
@@ -40,7 +40,7 @@ export default function AnimatedStats({ stats }: AnimatedStatsProps) {
   }, [])
 
   return (
-    <div ref={sectionRef} className="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <div ref={sectionRef} className="grid grid-cols-1 gap-6 md:grid-cols-3">
       {stats.map((stat, index) => (
         <AnimatedStatCard
           key={index}
@@ -91,19 +91,15 @@ function AnimatedStatCard({
 
   return (
     <div
-      className="flex flex-col items-center p-6 bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow border border-gray-100"
-      style={{
-        animation: isVisible ? `countUp 0.8s ease-out ${delay}s both` : 'none',
-      }}
+      className="surface-card h-full flex flex-col items-center gap-4 text-center"
+      style={{ animation: isVisible ? `fade-up 0.6s ease ${delay}s both` : 'none' }}
     >
-      <div className="w-14 h-14 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center mb-4 shadow-md">
-        {stat.icon}
-      </div>
-      <div className="text-4xl font-bold text-gray-900 mb-2">
+      <span className="stat-icon !w-12 !h-12">{stat.icon}</span>
+      <div className="text-4xl font-semibold text-[color:var(--color-fg)]">
         {count}
-        <span className="text-blue-600">{stat.suffix}</span>
+        <span className="text-[color:var(--color-muted)] text-2xl align-super">{stat.suffix}</span>
       </div>
-      <p className="text-gray-600 text-center font-medium">{stat.label}</p>
+      <p className="text-sm font-medium text-[color:var(--color-muted)]">{stat.label}</p>
     </div>
   )
 }

--- a/app/components/CookieConsentModal.tsx
+++ b/app/components/CookieConsentModal.tsx
@@ -15,7 +15,6 @@ declare global {
 
 export default function CookieConsentModal() {
   const [open, setOpen] = useState(false)
-  const [decision, setDecision] = useState<Consent | null>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -24,9 +23,8 @@ export default function CookieConsentModal() {
     if (!saved) setOpen(true)
     else {
       try {
-        const { value, v } = JSON.parse(saved)
+        const { v } = JSON.parse(saved)
         if (v !== CONSENT_VERSION) setOpen(true)
-        else setDecision(value)
       } catch {
         setOpen(true)
       }

--- a/app/components/CookieConsentModal.tsx
+++ b/app/components/CookieConsentModal.tsx
@@ -97,7 +97,6 @@ export default function CookieConsentModal() {
 
     const val: Consent = granted ? 'accepted' : 'rejected'
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ value: val, v: CONSENT_VERSION, t: Date.now() }))
-    setDecision(val)
     setOpen(false)
   }
 

--- a/app/components/Documents/DocumentCard.tsx
+++ b/app/components/Documents/DocumentCard.tsx
@@ -16,35 +16,56 @@ export default function DocumentCard({ document, language }: DocumentCardProps) 
 
   // Badge-Farbe nach Kategorie
   const badgeStyles = {
-    required: 'bg-red-100 text-red-800 border-red-200',
-    optional: 'bg-blue-100 text-blue-800 border-blue-200',
-    guide: 'bg-green-100 text-green-800 border-green-200'
+    required: {
+      background: 'color-mix(in srgb, var(--color-danger) 16%, white 84%)',
+      color: 'var(--color-danger)'
+    },
+    optional: {
+      background: 'color-mix(in srgb, var(--color-accent) 16%, white 84%)',
+      color: 'var(--color-accent-strong)'
+    },
+    guide: {
+      background: 'color-mix(in srgb, var(--color-success) 16%, white 84%)',
+      color: 'var(--color-success)'
+    }
   }[document.category];
 
   return (
-    <div className="bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-200 overflow-hidden border border-gray-200">
+    <div className="surface-card transition-transform duration-200 hover:-translate-y-1 overflow-hidden">
       {/* Header with Icon */}
-      <div className="relative h-32 bg-gradient-to-br from-blue-50 to-blue-100 flex items-center justify-center">
-        <FileText className="w-16 h-16 text-blue-600" strokeWidth={1.5} />
+      <div
+        className="relative h-32 flex items-center justify-center"
+        style={{
+          background: 'linear-gradient(135deg, color-mix(in srgb, var(--color-accent) 12%, white 88%), var(--color-surface))',
+        }}
+      >
+        <FileText className="w-16 h-16 text-[color:var(--color-accent-strong)]" strokeWidth={1.5} />
 
         {/* Kategorie Badge */}
-        <div className={`absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-bold border ${badgeStyles}`}>
+        <div
+          className="absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-bold"
+          style={{
+            background: badgeStyles.background,
+            color: badgeStyles.color,
+            border: '1px solid color-mix(in srgb, currentColor 25%, transparent)',
+          }}
+        >
           {t(`category.${document.category}`)}
         </div>
       </div>
 
       {/* Content */}
       <div className="p-5">
-        <h3 className="text-lg font-bold mb-2 text-gray-900">
+        <h3 className="text-lg font-semibold mb-2 text-[color:var(--color-fg)]">
           {translation.title}
         </h3>
 
-        <p className="text-sm text-gray-600 mb-4 line-clamp-3">
+        <p className="text-sm text-[color:var(--color-muted)] mb-4 line-clamp-3">
           {translation.description}
         </p>
 
         {/* Metadata */}
-        <div className="flex items-center gap-4 text-xs text-gray-500 mb-4 pb-4 border-b border-gray-100">
+        <div className="flex items-center gap-4 text-xs mb-4 pb-4 border-b border-[color:var(--color-border)]" style={{ color: 'color-mix(in srgb, var(--color-muted) 70%, white 30%)' }}>
           <span className="flex items-center gap-1">
             <FileText className="w-4 h-4" />
             {document.pages} {t('pages')}
@@ -61,13 +82,14 @@ export default function DocumentCard({ document, language }: DocumentCardProps) 
             href={externalUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors shadow-sm"
+            className="btn btn-primary w-full"
+            style={{ justifyContent: 'center' }}
           >
             <ExternalLink className="w-4 h-4" />
             {t('openExternal')}
           </a>
         ) : (
-          <p className="text-sm text-gray-500 text-center">
+          <p className="text-sm text-[color:var(--color-muted)] text-center">
             {t('noExternalLink')}
           </p>
         )}
@@ -79,21 +101,27 @@ export default function DocumentCard({ document, language }: DocumentCardProps) 
 
         {/* Help Text */}
         {translation.help && (
-          <div className="mt-3 p-3 bg-blue-50 rounded-lg border border-blue-100">
-            <p className="text-xs text-blue-800">
-              💡 {translation.help}
-            </p>
+          <div
+            className="mt-3 rounded-[var(--radius-sm)] border p-3"
+            style={{
+              background: 'color-mix(in srgb, var(--color-accent) 14%, white 86%)',
+              borderColor: 'color-mix(in srgb, var(--color-accent) 45%, transparent)',
+              color: 'var(--color-accent-strong)',
+            }}
+          >
+            <p className="text-xs">💡 {translation.help}</p>
           </div>
         )}
 
         {externalUrl && (
-          <p className="mt-4 text-xs text-gray-500 text-center">
+          <p className="mt-4 text-xs text-center" style={{ color: 'color-mix(in srgb, var(--color-muted) 70%, white 30%)' }}>
             {t('officialSource')}:{' '}
             <a
               href={externalUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 underline hover:text-blue-700"
+              className="underline"
+              style={{ color: 'var(--color-accent-strong)' }}
             >
               {new URL(externalUrl).hostname}
             </a>

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -14,35 +14,24 @@ export default function Footer() {
   const locale = Array.isArray(paramLocale) ? paramLocale[0] : paramLocale ?? defaultLocale
 
   return (
-    <footer className="bg-white/50 backdrop-blur-sm border-t border-gray-200 mt-20">
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="text-center text-gray-600 text-sm mb-4">
+    <footer className="footer mt-24">
+      <div className="layout-container section-tight text-center">
+        <div className="space-y-3 text-sm" style={{ color: 'var(--color-muted)' }}>
           <p>© 2025 {t('copyright')}</p>
-          <p className="mt-2 text-xs text-gray-500">
+          <p className="text-xs max-w-2xl mx-auto" style={{ color: 'color-mix(in srgb, var(--color-muted) 75%, white 25%)' }}>
             {t('disclaimer')}
           </p>
         </div>
-        <div className="flex justify-center gap-6 text-sm">
-          <Link
-            href={`/${locale}/impressum`}
-            className="text-gray-600 hover:text-blue-600 transition-colors underline"
-          >
-            {t('imprint')}
-          </Link>
-          <Link
-            href={`/${locale}/datenschutz`}
-            className="text-gray-600 hover:text-blue-600 transition-colors underline"
-          >
-            {t('privacy')}
-          </Link>
+        <div className="footer__links mt-6 flex flex-wrap justify-center gap-6 text-sm">
+          <Link href={`/${locale}/impressum`}>{t('imprint')}</Link>
+          <Link href={`/${locale}/datenschutz`}>{t('privacy')}</Link>
           <button
             type="button"
             onClick={() => window.showCookieSettings?.()}
-            className="text-gray-600 hover:text-blue-600 transition-colors underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 rounded-sm"
+            className="btn btn-ghost"
           >
             Cookie-Einstellungen
           </button>
-
         </div>
       </div>
     </footer>

--- a/app/components/FormularAssistent/FormularWizard.tsx
+++ b/app/components/FormularAssistent/FormularWizard.tsx
@@ -139,29 +139,22 @@ export default function FormularWizard() {
   };
 
   return (
-    <div className="max-w-5xl mx-auto">
+    <div className="max-w-5xl mx-auto space-y-6">
       {/* Header */}
-      <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-6">
-        <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
-          {t('titel')}
-        </h1>
-        <p className="text-gray-600 mb-4">
-          {t('beschreibung')}
-        </p>
+      <div className="surface-card space-y-4">
+        <h1 className="text-3xl md:text-4xl font-semibold text-[color:var(--color-fg)]">{t('titel')}</h1>
+        <p className="text-[color:var(--color-muted)]">{t('beschreibung')}</p>
 
-        {/* Disclaimer */}
-        <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded-r-lg">
+        <div className="rounded-[var(--radius-sm)] border border-[color-mix(in srgb, var(--color-warning) 35%, transparent)] bg-[color-mix(in srgb, var(--color-warning) 12%, white 88%)] p-4">
           <div className="flex items-start gap-3">
-            <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-            <p className="text-sm text-amber-900">
-              {t('disclaimer')}
-            </p>
+            <AlertCircle className="w-5 h-5 text-[color:var(--color-warning)] flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-[color:var(--color-warning)]">{t('disclaimer')}</p>
           </div>
         </div>
       </div>
 
       {/* Fortschrittsanzeige */}
-      <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-6">
+      <div className="surface-card">
         <FortschrittsAnzeige
           schritte={SCHRITTE}
           aktuellerSchritt={aktuellerSchritt}
@@ -175,7 +168,7 @@ export default function FormularWizard() {
       </div>
 
       {/* Haupt-Formular */}
-      <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-6">
+      <div className="surface-card">
         {aktuellerSchritt === 0 && (
           <SchrittAntragsteller
             daten={formularDaten}
@@ -209,23 +202,15 @@ export default function FormularWizard() {
       </div>
 
       {/* Navigation */}
-      <div className="bg-white rounded-xl shadow-lg p-6 flex flex-col sm:flex-row gap-4 justify-between items-center">
-        <div className="flex gap-3">
-          <button
-            onClick={handleEntwurfSpeichern}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg font-medium transition-colors"
-          >
-            <Save className="w-4 h-4" />
-            {t('entwurfSpeichern')}
-          </button>
-        </div>
+      <div className="surface-card flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <button onClick={handleEntwurfSpeichern} className="btn btn-secondary">
+          <Save className="w-4 h-4" />
+          {t('entwurfSpeichern')}
+        </button>
 
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3">
           {aktuellerSchritt > 0 && (
-            <button
-              onClick={vorherigerSchritt}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg font-semibold transition-colors"
-            >
+            <button onClick={vorherigerSchritt} className="btn btn-ghost">
               <ChevronLeft className="w-5 h-5" />
               {t('zurueck')}
             </button>
@@ -235,16 +220,14 @@ export default function FormularWizard() {
             <button
               onClick={naechsterSchritt}
               disabled={!istSchrittValid()}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg font-semibold transition-colors"
+              className="btn btn-primary"
+              style={{ justifyContent: 'center' }}
             >
               {t('weiter')}
               <ChevronRight className="w-5 h-5" />
             </button>
           ) : (
-            <button
-              onClick={handlePDFErstellen}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg font-semibold transition-colors"
-            >
+            <button onClick={handlePDFErstellen} className="btn btn-primary" style={{ justifyContent: 'center' }}>
               <FileDown className="w-5 h-5" />
               {t('pdfErstellen')}
             </button>

--- a/app/components/FormularAssistent/FortschrittsAnzeige.tsx
+++ b/app/components/FormularAssistent/FortschrittsAnzeige.tsx
@@ -20,7 +20,7 @@ export default function FortschrittsAnzeige({
   return (
     <div className="relative">
       {/* Desktop Version */}
-      <div className="hidden md:flex justify-between items-start">
+      <div className="hidden md:flex justify-between items-start gap-6">
         {schritte.map((schritt, index) => {
           const istAbgeschlossen = index < aktuellerSchritt;
           const istAktuell = index === aktuellerSchritt;
@@ -31,9 +31,12 @@ export default function FortschrittsAnzeige({
               {/* Verbindungslinie */}
               {index < schritte.length - 1 && (
                 <div
-                  className={`absolute top-6 left-[50%] w-full h-1 -z-10 transition-all duration-300 ${
-                    istAbgeschlossen ? 'bg-green-500' : 'bg-gray-200'
-                  }`}
+                  className="absolute top-6 left-[50%] w-full h-[3px] -z-10 transition-all duration-300"
+                  style={{
+                    background: istAbgeschlossen
+                      ? 'var(--color-success)'
+                      : 'color-mix(in srgb, var(--color-muted) 25%, white 75%)',
+                  }}
                 />
               )}
 
@@ -47,13 +50,23 @@ export default function FortschrittsAnzeige({
               >
                 {/* Kreis */}
                 <div
-                  className={`w-12 h-12 rounded-full flex items-center justify-center text-xl font-bold border-4 transition-all duration-300 ${
-                    istAbgeschlossen
-                      ? 'bg-green-500 border-green-500 text-white'
+                  className="w-12 h-12 rounded-full flex items-center justify-center text-xl font-semibold border-2 transition-all duration-300"
+                  style={{
+                    background: istAbgeschlossen
+                      ? 'var(--color-success)'
                       : istAktuell
-                      ? 'bg-blue-600 border-blue-600 text-white ring-4 ring-blue-200'
-                      : 'bg-white border-gray-300 text-gray-400'
-                  }`}
+                      ? 'var(--color-accent)'
+                      : 'var(--color-surface)',
+                    color: istAbgeschlossen || istAktuell ? '#fff' : 'var(--color-muted)',
+                    borderColor: istAbgeschlossen
+                      ? 'var(--color-success)'
+                      : istAktuell
+                      ? 'var(--color-accent)'
+                      : 'var(--color-border)',
+                    boxShadow: istAktuell
+                      ? '0 0 0 6px color-mix(in srgb, var(--color-accent) 20%, transparent)'
+                      : 'none',
+                  }}
                 >
                   {istAbgeschlossen ? <Check className="w-6 h-6" /> : schritt.icon}
                 </div>
@@ -61,13 +74,18 @@ export default function FortschrittsAnzeige({
                 {/* Titel */}
                 <div className="text-center">
                   <div
-                    className={`text-sm font-semibold ${
-                      istAktuell ? 'text-blue-600' : istAbgeschlossen ? 'text-green-600' : 'text-gray-500'
-                    }`}
+                    className="text-sm font-semibold"
+                    style={{
+                      color: istAktuell
+                        ? 'var(--color-accent)'
+                        : istAbgeschlossen
+                        ? 'var(--color-success)'
+                        : 'var(--color-muted)',
+                    }}
                   >
                     {t(`schritte.${schritt.id}.titel`)}
                   </div>
-                  <div className="text-xs text-gray-500 mt-0.5">
+                  <div className="text-xs mt-0.5" style={{ color: 'color-mix(in srgb, var(--color-muted) 60%, white 40%)' }}>
                     Schritt {index + 1} von {schritte.length}
                   </div>
                 </div>
@@ -80,19 +98,28 @@ export default function FortschrittsAnzeige({
       {/* Mobile Version */}
       <div className="md:hidden">
         <div className="flex items-center justify-between mb-4">
-          <span className="text-sm font-semibold text-gray-700">
+          <span className="text-sm font-semibold" style={{ color: 'var(--color-fg)' }}>
             Schritt {aktuellerSchritt + 1} von {schritte.length}
           </span>
-          <span className="text-sm text-gray-600">
+          <span className="text-sm" style={{ color: 'var(--color-muted)' }}>
             {t(`schritte.${schritte[aktuellerSchritt].id}.titel`)}
           </span>
         </div>
 
         {/* Progress Bar */}
-        <div className="w-full bg-gray-200 rounded-full h-2.5">
+        <div
+          className="w-full rounded-full h-2.5"
+          style={{ background: 'color-mix(in srgb, var(--color-muted) 18%, white 82%)' }}
+        >
           <div
-            className="bg-blue-600 h-2.5 rounded-full transition-all duration-300"
-            style={{ width: `${((aktuellerSchritt + 1) / schritte.length) * 100}%` }}
+            className="h-2.5 rounded-full transition-all duration-300"
+            role="presentation"
+            aria-hidden
+            data-testid="progress-indicator"
+            style={{
+              width: `${((aktuellerSchritt + 1) / schritte.length) * 100}%`,
+              background: 'var(--color-accent)',
+            }}
           />
         </div>
 
@@ -105,9 +132,9 @@ export default function FortschrittsAnzeige({
             return (
               <div
                 key={schritt.id}
-                className={`text-2xl ${
-                  istAbgeschlossen ? 'opacity-50' : istAktuell ? 'scale-125' : 'opacity-30'
-                } transition-all`}
+                className={`text-2xl transition-all ${
+                  istAbgeschlossen ? 'opacity-50' : istAktuell ? 'scale-125 text-[color:var(--color-accent)]' : 'opacity-30'
+                }`}
               >
                 {schritt.icon}
               </div>

--- a/app/components/FormularAssistent/schritte/SchrittAntragsteller.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittAntragsteller.tsx
@@ -31,14 +31,14 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
           {t('felder.name.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
+          <User className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="name"
             type="text"
             value={daten.name}
             onChange={(e) => onChange('name', e.target.value)}
             placeholder={t('felder.name.platzhalter')}
-            className="w-full pl-12 pr-4"
+            className="w-full input-with-icon"
             required
           />
         </div>
@@ -53,14 +53,14 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
           {t('felder.kontaktperson.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <Users className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
+          <Users className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="kontaktperson"
             type="text"
             value={daten.kontaktperson}
             onChange={(e) => onChange('kontaktperson', e.target.value)}
             placeholder={t('felder.kontaktperson.platzhalter')}
-            className="w-full pl-12 pr-4"
+            className="w-full input-with-icon"
             required
           />
         </div>
@@ -75,14 +75,14 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
           {t('felder.telefon.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
+          <Phone className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="telefon"
             type="tel"
             value={daten.telefon}
             onChange={(e) => onChange('telefon', e.target.value)}
             placeholder={t('felder.telefon.platzhalter')}
-            className="w-full pl-12 pr-4"
+            className="w-full input-with-icon"
             required
           />
         </div>
@@ -94,14 +94,14 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
           {t('felder.email.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
+          <Mail className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="email"
             type="email"
             value={daten.email}
             onChange={(e) => onChange('email', e.target.value)}
             placeholder={t('felder.email.platzhalter')}
-            className="w-full pl-12 pr-4"
+            className="w-full input-with-icon"
             required
           />
         </div>

--- a/app/components/FormularAssistent/schritte/SchrittAntragsteller.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittAntragsteller.tsx
@@ -16,73 +16,73 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
-        <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
-          <User className="w-6 h-6 text-blue-600" />
-        </div>
+        <span className="stat-icon !w-12 !h-12">
+          <User className="w-6 h-6" />
+        </span>
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{t('titel')}</h2>
-          <p className="text-gray-600">{t('beschreibung')}</p>
+          <h2 className="text-2xl font-semibold text-[color:var(--color-fg)]">{t('titel')}</h2>
+          <p className="text-[color:var(--color-muted)]">{t('beschreibung')}</p>
         </div>
       </div>
 
       {/* Name und Anschrift */}
       <div>
-        <label htmlFor="name" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.name.label')} <span className="text-red-500">*</span>
+        <label htmlFor="name">
+          {t('felder.name.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="name"
             type="text"
             value={daten.name}
             onChange={(e) => onChange('name', e.target.value)}
             placeholder={t('felder.name.platzhalter')}
-            className="w-full pl-11 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            className="w-full pl-12 pr-4"
             required
           />
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
+        <p className="mt-1.5 text-sm" style={{ color: 'color-mix(in srgb, var(--color-muted) 80%, white 20%)' }}>
           {t('felder.name.hilfe')}
         </p>
       </div>
 
       {/* Kontaktperson */}
       <div>
-        <label htmlFor="kontaktperson" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.kontaktperson.label')} <span className="text-red-500">*</span>
+        <label htmlFor="kontaktperson">
+          {t('felder.kontaktperson.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <Users className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <Users className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="kontaktperson"
             type="text"
             value={daten.kontaktperson}
             onChange={(e) => onChange('kontaktperson', e.target.value)}
             placeholder={t('felder.kontaktperson.platzhalter')}
-            className="w-full pl-11 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            className="w-full pl-12 pr-4"
             required
           />
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
+        <p className="mt-1.5 text-sm" style={{ color: 'color-mix(in srgb, var(--color-muted) 80%, white 20%)' }}>
           {t('felder.kontaktperson.hilfe')}
         </p>
       </div>
 
       {/* Telefon */}
       <div>
-        <label htmlFor="telefon" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.telefon.label')} <span className="text-red-500">*</span>
+        <label htmlFor="telefon">
+          {t('felder.telefon.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="telefon"
             type="tel"
             value={daten.telefon}
             onChange={(e) => onChange('telefon', e.target.value)}
             placeholder={t('felder.telefon.platzhalter')}
-            className="w-full pl-11 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            className="w-full pl-12 pr-4"
             required
           />
         </div>
@@ -90,22 +90,22 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
 
       {/* Email */}
       <div>
-        <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.email.label')} <span className="text-red-500">*</span>
+        <label htmlFor="email">
+          {t('felder.email.label')} <span style={{ color: 'var(--color-danger)' }}>*</span>
         </label>
         <div className="relative">
-          <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[color:var(--color-muted)]" />
           <input
             id="email"
             type="email"
             value={daten.email}
             onChange={(e) => onChange('email', e.target.value)}
             placeholder={t('felder.email.platzhalter')}
-            className="w-full pl-11 pr-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            className="w-full pl-12 pr-4"
             required
           />
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
+        <p className="mt-1.5 text-sm" style={{ color: 'color-mix(in srgb, var(--color-muted) 80%, white 20%)' }}>
           {t('felder.email.hilfe')}
         </p>
       </div>

--- a/app/components/FormularAssistent/schritte/SchrittFlaechen.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittFlaechen.tsx
@@ -57,7 +57,7 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
             value={daten.gesamtflaeche}
             onChange={(e) => onChange('gesamtflaeche', e.target.value)}
             placeholder="z.B. 415"
-            className="w-full px-4 py-3 pr-16 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            className="w-full input-with-unit border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
             required
           />
           <div className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 font-medium">

--- a/app/components/FormularAssistent/schritte/SchrittStandort.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittStandort.tsx
@@ -46,7 +46,7 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
     setLoading(true);
     try {
       const pois = await getNearbyPOIs(address.coordinates.lng, address.coordinates.lat, 200);
-      const riskAssessment = analyzePOIs(pois, address);
+      const riskAssessment = analyzePOIs(pois);
 
       // Alles im addressCheckerData speichern
       onChange('addressCheckerData', {

--- a/app/components/LanguageBanner.tsx
+++ b/app/components/LanguageBanner.tsx
@@ -69,62 +69,37 @@ export default function LanguageBanner() {
   if (!show || !detectedLocale) return null
 
   return (
-    <div className="fixed top-16 left-0 right-0 z-50 animate-slideDown">
-      <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white shadow-lg">
-        <div className="max-w-7xl mx-auto px-4 py-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <div className="flex-shrink-0">
-                <svg
-                  className="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
-                  />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <p className="text-sm md:text-base font-medium">
-                  {suggestions[detectedLocale]}
-                </p>
-                <p className="text-xs md:text-sm opacity-90 mt-1">
-                  Browser language: {languageNames[detectedLocale].native}
-                </p>
-              </div>
+    <div className="fixed top-16 inset-x-0 z-50" role="status" style={{ animation: 'fade-up 320ms ease forwards' }}>
+      <div className="layout-container">
+        <div className="surface-card flex flex-col gap-4 md:flex-row md:items-center md:justify-between" style={{ boxShadow: '0 24px 60px -32px rgba(15, 23, 32, 0.35)' }}>
+          <div className="flex items-start gap-3 text-left">
+            <span className="stat-icon !w-9 !h-9 rounded-full">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+              </svg>
+            </span>
+            <div className="space-y-2">
+              <p className="text-sm md:text-base font-medium text-[color:var(--color-fg)] text-balance">
+                {suggestions[detectedLocale]}
+              </p>
+              <p className="text-xs md:text-sm" style={{ color: 'color-mix(in srgb, var(--color-muted) 80%, white 20%)' }}>
+                Browser language: {languageNames[detectedLocale].native}
+              </p>
             </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <button
-                onClick={handleChangeLanguage}
-                className="px-4 py-2 bg-white text-blue-600 rounded-lg font-semibold hover:bg-blue-50 transition-colors text-sm md:text-base whitespace-nowrap"
-              >
-                Change to {languageNames[detectedLocale].native}
-              </button>
-              <button
-                onClick={handleDismiss}
-                className="p-2 hover:bg-blue-800 rounded-lg transition-colors"
-                aria-label="Close"
-              >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
+          </div>
+          <div className="flex items-center gap-2 md:gap-3 self-end md:self-center">
+            <button onClick={handleChangeLanguage} className="btn btn-primary text-sm md:text-base whitespace-nowrap">
+              Change to {languageNames[detectedLocale].native}
+            </button>
+            <button
+              onClick={handleDismiss}
+              className="btn btn-ghost !p-2"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
         </div>
       </div>

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -61,47 +61,51 @@ export default function LanguageSwitcher() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="group flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-white to-gray-50 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all duration-300 shadow-sm relative overflow-hidden"
+        className="btn btn-secondary whitespace-nowrap min-w-[11rem]"
         aria-label={t('selectLanguage')}
+        style={{
+          justifyContent: 'space-between',
+          boxShadow: isOpen ? '0 0 0 4px var(--color-accent-soft)' : undefined,
+        }}
       >
-        <div className="absolute inset-0 bg-gradient-to-r from-blue-500/0 via-blue-500/5 to-blue-500/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
-        <span className="text-xl relative z-10 transform group-hover:scale-110 transition-transform duration-300">{currentLanguage.flag}</span>
-        <span className="font-medium text-gray-700 relative z-10 group-hover:text-blue-600 transition-colors duration-300">{currentLanguage.name}</span>
-        <svg
-          className={`w-4 h-4 relative z-10 transition-all duration-300 group-hover:text-blue-600 ${isOpen ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
+        <span className="text-xl">{currentLanguage.flag}</span>
+        <span className="font-medium text-sm" style={{ color: 'var(--color-fg)' }}>
+          {currentLanguage.name}
+        </span>
+        <svg className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
       {isOpen && (
-        <div className="absolute top-full mt-2 right-0 bg-white border border-gray-200 rounded-lg shadow-xl overflow-hidden z-50 min-w-[200px] animate-slideDown backdrop-blur-sm">
-          {languages.map((lang, index) => (
-            <button
-              key={lang.code}
-              onClick={() => handleLanguageChange(lang.code)}
-              className={`w-full flex items-center gap-3 px-4 py-3 hover:bg-gradient-to-r hover:from-blue-50 hover:to-blue-100/50 transition-all duration-200 relative group ${
-                lang.code === locale ? 'bg-gradient-to-r from-blue-50 to-blue-100/50 text-blue-600' : 'text-gray-700'
-              }`}
-              style={{ animationDelay: `${index * 0.03}s` }}
-            >
-              <span className="text-xl transform group-hover:scale-125 transition-transform duration-200">{lang.flag}</span>
-              <span className="font-medium group-hover:translate-x-1 transition-transform duration-200">{lang.name}</span>
-              {lang.code === locale && (
-                <svg className="w-5 h-5 ml-auto animate-scaleIn" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fillRule="evenodd"
-                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              )}
-              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700"></div>
-            </button>
-          ))}
+        <div className="surface-card absolute top-full right-0 mt-3 min-w-[220px] p-2 z-50">
+          <div className="flex flex-col gap-1">
+            {languages.map((lang) => {
+              const active = lang.code === locale
+              return (
+                <button
+                  key={lang.code}
+                  onClick={() => handleLanguageChange(lang.code)}
+                  className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
+                    active ? 'bg-[color:var(--color-accent-soft)] text-[color:var(--color-accent-strong)]' : 'text-[color:var(--color-muted)]'
+                  }`}
+                  style={{ justifyContent: 'space-between' }}
+                >
+                  <span className="text-lg">{lang.flag}</span>
+                  <span className="flex-1 text-left font-medium">{lang.name}</span>
+                  {active && (
+                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                      <path
+                        fillRule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
+                </button>
+              )
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/app/components/NavLink.tsx
+++ b/app/components/NavLink.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
+
+interface NavLinkProps {
+  href: string
+  children: ReactNode
+  className?: string
+}
+
+export default function NavLink({ href, children, className = '' }: NavLinkProps) {
+  const pathname = usePathname()
+  const isActive = pathname === href || (href !== '/' && pathname?.startsWith(`${href}/`))
+  const classes = ['nav-link']
+
+  if (isActive) {
+    classes.push('is-active')
+  }
+
+  if (className) {
+    classes.push(className)
+  }
+
+  return (
+    <Link href={href} aria-current={isActive ? 'page' : undefined} className={classes.join(' ')}>
+      {children}
+    </Link>
+  )
+}

--- a/app/components/POIList.tsx
+++ b/app/components/POIList.tsx
@@ -22,9 +22,9 @@ export default function POIList({ pois }: POIListProps) {
 
   if (pois.length === 0) {
     return (
-      <div className="p-8 text-center bg-green-50 border-2 border-green-200 rounded-xl">
-        <span className="text-4xl mb-3 block">✅</span>
-        <p className="text-green-800 font-medium">
+      <div className="surface-card text-center space-y-3">
+        <span className="text-4xl">✅</span>
+        <p className="font-medium" style={{ color: 'var(--color-success)' }}>
           {t('pois.empty')}
         </p>
       </div>
@@ -38,23 +38,38 @@ export default function POIList({ pois }: POIListProps) {
         const icon = getPOIIcon(type);
         const categoryName = t(`pois.categories.${type}`);
 
-        // Risk badge styling
-        const riskBadgeClasses = {
-          high: 'bg-red-100 text-red-800 border-red-200',
-          medium: 'bg-yellow-100 text-yellow-800 border-yellow-200',
-          low: 'bg-blue-100 text-blue-800 border-blue-200'
+        const riskStyles = {
+          high: {
+            background: 'color-mix(in srgb, var(--color-danger) 18%, white 82%)',
+            color: 'var(--color-danger)'
+          },
+          medium: {
+            background: 'color-mix(in srgb, var(--color-warning) 22%, white 78%)',
+            color: 'var(--color-warning)'
+          },
+          low: {
+            background: 'color-mix(in srgb, var(--color-accent) 16%, white 84%)',
+            color: 'var(--color-accent-strong)'
+          }
         }[riskLevel];
 
         return (
-          <div key={type} className="border-b border-gray-200 pb-6 last:border-b-0 last:pb-0">
+          <div key={type} className="border-b border-[color:var(--color-border)] pb-6 last:border-b-0 last:pb-0">
             {/* Category Header */}
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="flex items-center gap-2 text-lg font-bold text-gray-900">
+            <div className="flex items-center justify-between mb-3 gap-3">
+              <h3 className="flex items-center gap-2 text-lg font-semibold text-[color:var(--color-fg)]">
                 <span className="text-2xl">{icon}</span>
                 {categoryName}
-                <span className="text-sm font-normal text-gray-500">({items.length})</span>
+                <span className="text-sm font-normal text-[color:var(--color-muted)]">({items.length})</span>
               </h3>
-              <span className={`px-3 py-1 rounded-full text-xs font-semibold border ${riskBadgeClasses}`}>
+              <span
+                className="badge text-xs"
+                style={{
+                  background: riskStyles.background,
+                  color: riskStyles.color,
+                  border: '1px solid color-mix(in srgb, currentColor 25%, transparent)',
+                }}
+              >
                 {t(`badges.${riskLevel}`)}
               </span>
             </div>
@@ -64,10 +79,10 @@ export default function POIList({ pois }: POIListProps) {
               {items.map((poi, index) => (
                 <li
                   key={index}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+                  className="flex items-center justify-between rounded-[var(--radius-sm)] border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] px-4 py-3 transition hover:border-[color:var(--color-accent)] hover:bg-[color:var(--color-accent-soft)]"
                 >
-                  <span className="text-gray-800 font-medium">{poi.name || 'Unbenannt'}</span>
-                  <span className="text-sm font-semibold text-gray-600">
+                  <span className="font-medium text-[color:var(--color-fg)]">{poi.name || 'Unbenannt'}</span>
+                  <span className="text-sm font-semibold text-[color:var(--color-muted)]">
                     {poi.distance ? `${Math.round(poi.distance)}m` : t('pois.nearby')}
                   </span>
                 </li>

--- a/app/components/RiskAssessment.tsx
+++ b/app/components/RiskAssessment.tsx
@@ -2,15 +2,13 @@
 
 import { useTranslations } from 'next-intl';
 import type { RiskAssessment as RiskAssessmentType } from '@/app/utils/poi-checker';
-import type { Address } from '@/app/lib/viennagis-api';
 import { AlertTriangle, Lightbulb, Info } from 'lucide-react';
 
 interface RiskAssessmentProps {
   assessment: RiskAssessmentType;
-  address: Address;
 }
 
-export default function RiskAssessment({ assessment, address }: RiskAssessmentProps) {
+export default function RiskAssessment({ assessment }: RiskAssessmentProps) {
   const t = useTranslations('addressChecker.risk');
 
   // Risk level styling
@@ -38,32 +36,30 @@ export default function RiskAssessment({ assessment, address }: RiskAssessmentPr
   const colors = riskColors[assessment.overallRisk];
 
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 md:p-8">
-      <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6">
-        {t('title')}
-      </h2>
+    <div className="surface-card space-y-6">
+      <h2 className="text-2xl md:text-3xl font-semibold text-[color:var(--color-fg)]">{t('title')}</h2>
 
       {/* Risk Score Card */}
       <div
-        className="rounded-xl p-6 mb-6 border-4"
+        className="rounded-[var(--radius)] p-6 border"
         style={{ borderColor: colors.border, backgroundColor: colors.bg }}
       >
-        <div className="flex items-center justify-between mb-4">
-          <span
-            className="text-2xl md:text-3xl font-bold"
-            style={{ color: colors.text }}
-          >
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <span className="text-2xl md:text-3xl font-semibold" style={{ color: colors.text }}>
             {t(`levels.${assessment.overallRisk}`)}
           </span>
-          <span className="text-lg md:text-xl font-semibold text-gray-600">
+          <span className="text-lg md:text-xl font-medium text-[color:var(--color-muted)]">
             {assessment.riskPoints}/100 {t('points')}
           </span>
         </div>
 
         {/* Progress Bar */}
-        <div className="h-4 bg-gray-200 rounded-full overflow-hidden">
+        <div
+          className="mt-4 h-3 rounded-full"
+          style={{ background: 'color-mix(in srgb, var(--color-muted) 18%, white 82%)' }}
+        >
           <div
-            className="h-full transition-all duration-500 ease-out rounded-full"
+            className="h-full rounded-full transition-all duration-500 ease-out"
             style={{
               width: `${assessment.riskPoints}%`,
               backgroundColor: colors.fill
@@ -74,19 +70,19 @@ export default function RiskAssessment({ assessment, address }: RiskAssessmentPr
 
       {/* Warnings */}
       {assessment.warnings.length > 0 && (
-        <div className="mb-6">
-          <h3 className="text-xl font-bold text-gray-900 mb-3 flex items-center gap-2">
-            <AlertTriangle className="w-6 h-6 text-yellow-600" />
+        <div className="space-y-3">
+          <h3 className="text-xl font-semibold text-[color:var(--color-fg)] flex items-center gap-2">
+            <AlertTriangle className="w-6 h-6 text-[color:var(--color-warning)]" />
             {t('warnings')}
           </h3>
           <ul className="space-y-3">
             {assessment.warnings.map((warning, index) => (
               <li
                 key={index}
-                className="flex gap-3 p-4 bg-yellow-50 border-l-4 border-yellow-400 rounded-r-lg"
+                className="flex gap-3 rounded-[var(--radius-sm)] border border-[color-mix(in srgb, var(--color-warning) 40%, transparent)] bg-[color-mix(in srgb, var(--color-warning) 12%, white 88%)] p-4"
               >
                 <span className="text-2xl flex-shrink-0">⚠️</span>
-                <p className="text-gray-800 leading-relaxed">{warning}</p>
+                <p className="text-[color:var(--color-fg)] leading-relaxed">{warning}</p>
               </li>
             ))}
           </ul>
@@ -95,19 +91,19 @@ export default function RiskAssessment({ assessment, address }: RiskAssessmentPr
 
       {/* Recommendations */}
       {assessment.recommendations.length > 0 && (
-        <div className="mb-6">
-          <h3 className="text-xl font-bold text-gray-900 mb-3 flex items-center gap-2">
-            <Lightbulb className="w-6 h-6 text-blue-600" />
+        <div className="space-y-3">
+          <h3 className="text-xl font-semibold text-[color:var(--color-fg)] flex items-center gap-2">
+            <Lightbulb className="w-6 h-6 text-[color:var(--color-accent)]" />
             {t('recommendations')}
           </h3>
           <ul className="space-y-3">
             {assessment.recommendations.map((rec, index) => (
               <li
                 key={index}
-                className="flex gap-3 p-4 bg-blue-50 border-l-4 border-blue-400 rounded-r-lg"
+                className="flex gap-3 rounded-[var(--radius-sm)] border border-[color-mix(in srgb, var(--color-accent) 35%, transparent)] bg-[color-mix(in srgb, var(--color-accent) 12%, white 88%)] p-4"
               >
                 <span className="text-2xl flex-shrink-0">💡</span>
-                <p className="text-gray-800 leading-relaxed">{rec}</p>
+                <p className="text-[color:var(--color-fg)] leading-relaxed">{rec}</p>
               </li>
             ))}
           </ul>
@@ -115,14 +111,12 @@ export default function RiskAssessment({ assessment, address }: RiskAssessmentPr
       )}
 
       {/* Disclaimer */}
-      <div className="p-4 bg-green-50 border-l-4 border-green-500 rounded-r-lg">
+      <div className="rounded-[var(--radius-sm)] border border-[color-mix(in srgb, var(--color-success) 35%, transparent)] bg-[color-mix(in srgb, var(--color-success) 12%, white 88%)] p-4">
         <div className="flex gap-3">
-          <Info className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+          <Info className="w-5 h-5 text-[color:var(--color-success)] flex-shrink-0 mt-0.5" />
           <div>
-            <h4 className="font-bold text-green-900 mb-1">{t('disclaimer.title')}</h4>
-            <p className="text-sm text-green-800 leading-relaxed">
-              {t('disclaimer.text')}
-            </p>
+            <h4 className="font-semibold text-[color:var(--color-success)] mb-1">{t('disclaimer.title')}</h4>
+            <p className="text-sm text-[color:var(--color-success)] leading-relaxed">{t('disclaimer.text')}</p>
           </div>
         </div>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,299 +1,545 @@
 @import "tailwindcss";
+@import "./tokens.css";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+@layer base {
+  html {
+    scroll-behavior: smooth;
+    font-family: var(--font-sans);
+    background: var(--color-bg);
+    color: var(--color-fg);
+    text-rendering: optimizeLegibility;
+  }
 
-  /* Extended Color Scheme */
-  --color-primary: #3b82f6;
-  --color-primary-dark: #2563eb;
-  --color-secondary: #FF6B35;
-  --color-secondary-dark: #e55a28;
-  --color-success: #22C55E;
-  --color-success-dark: #16a34a;
-  --color-warning: #F59E0B;
-  --color-warning-dark: #d97706;
-  --color-info: #3B82F6;
-  --color-info-dark: #2563eb;
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1.6;
+    letter-spacing: -0.01em;
+  }
 
-  /* Neutral Colors */
-  --color-gray-50: #f9fafb;
-  --color-gray-100: #f3f4f6;
-  --color-gray-200: #e5e7eb;
-  --color-gray-300: #d1d5db;
-  --color-gray-500: #6b7280;
-  --color-gray-700: #374151;
-  --color-gray-900: #111827;
+  main {
+    position: relative;
+    isolation: isolate;
+  }
 
-  /* Shadow Tokens */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    color: var(--color-fg);
+    letter-spacing: -0.015em;
+    margin-top: 0;
+  }
 
-  /* Transition Tokens */
-  --transition-fast: 0.15s ease;
-  --transition-base: 0.2s ease;
-  --transition-slow: 0.3s ease;
+  h1 {
+    font-size: clamp(2.5rem, 3.5vw, 3.25rem);
+    line-height: 1.1;
+  }
+
+  h2 {
+    font-size: clamp(2rem, 3vw, 2.5rem);
+    line-height: 1.15;
+  }
+
+  h3 {
+    font-size: clamp(1.5rem, 2vw, 1.875rem);
+    line-height: 1.2;
+  }
+
+  h4 {
+    font-size: clamp(1.25rem, 1.5vw, 1.5rem);
+    line-height: 1.25;
+  }
+
+  p,
+  ul,
+  ol {
+    color: var(--color-muted);
+    max-width: 72ch;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+    transition: color var(--transition), opacity var(--transition);
+  }
+
+  strong {
+    color: var(--color-fg);
+  }
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
+@layer components {
+  .layout-container {
+    width: min(100%, var(--container-w));
+    margin-inline: auto;
+    padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+  }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
-}
+  .section {
+    padding-block: clamp(3.5rem, 6vw, 5rem);
+  }
 
-/* Custom Animations */
-@keyframes fadeIn {
-  from {
+  .section-tight {
+    padding-block: clamp(2.5rem, 4vw, 3.5rem);
+  }
+
+  .section-bleed {
+    padding-block: clamp(4rem, 7vw, 6rem);
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .surface-card {
+    background: var(--color-surface);
+    border-radius: var(--radius);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-soft);
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    transition: transform var(--transition), box-shadow var(--transition);
+  }
+
+  .surface-card:hover,
+  .surface-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-hover);
+  }
+
+  .surface-muted {
+    background: var(--color-surface-muted);
+    border-radius: var(--radius);
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0.85rem 1.75rem;
+    font-weight: 600;
+    border-radius: calc(var(--radius) - 6px);
+    border: 1px solid transparent;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  }
+
+  .btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .btn-primary {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 14px 30px -18px rgba(29, 125, 140, 0.8);
+  }
+
+  .btn-primary:hover,
+  .btn-primary:focus-visible {
+    background: var(--color-accent-strong);
+    box-shadow: 0 16px 32px -16px rgba(22, 103, 116, 0.5);
+  }
+
+  .btn-secondary {
+    background: rgba(29, 125, 140, 0.1);
+    color: var(--color-accent-strong);
+    border-color: rgba(29, 125, 140, 0.2);
+  }
+
+  .btn-secondary:hover,
+  .btn-secondary:focus-visible {
+    background: rgba(29, 125, 140, 0.16);
+    border-color: rgba(29, 125, 140, 0.32);
+  }
+
+  .btn-ghost {
+    background: transparent;
+    color: var(--color-muted);
+    border-color: transparent;
+  }
+
+  .btn-ghost:hover,
+  .btn-ghost:focus-visible {
+    color: var(--color-accent-strong);
+    background: var(--color-accent-soft);
+  }
+
+  .nav-link {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    padding: 0.75rem 0.5rem;
+    font-weight: 500;
+    color: var(--color-muted);
+    transition: color var(--transition);
+  }
+
+  .nav-link::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0.5rem;
+    bottom: 0.2rem;
+    height: 0.2rem;
+    border-radius: 999px;
+    background: transparent;
+    transition: background var(--transition), transform var(--transition);
+    transform: scaleX(0);
+    transform-origin: center;
+  }
+
+  .nav-link:hover {
+    color: var(--color-fg);
+  }
+
+  .nav-link:hover::after {
+    background: var(--color-accent-soft);
+    transform: scaleX(1);
+  }
+
+  .nav-link.is-active {
+    color: var(--color-fg);
+    font-weight: 600;
+  }
+
+  .nav-link.is-active::after {
+    background: var(--color-accent);
+    transform: scaleX(1);
+  }
+
+  .site-nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+    backdrop-filter: blur(14px);
+    border-bottom: 1px solid var(--color-border);
+    transition: box-shadow var(--transition), background var(--transition);
+  }
+
+  .site-nav::after {
+    content: '';
+    position: absolute;
+    inset: auto 0 0;
+    height: 1px;
+    background: rgba(0, 0, 0, 0.04);
     opacity: 0;
-    transform: translateY(20px);
+    transition: opacity var(--transition);
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
-@keyframes slideInFromLeft {
-  from {
-    opacity: 0;
-    transform: translateX(-50px);
+  .site-nav[data-elevated='true'] {
+    box-shadow: 0 12px 24px -20px rgba(18, 24, 32, 0.65);
   }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
 
-@keyframes slideInFromRight {
-  from {
-    opacity: 0;
-    transform: translateX(50px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-@keyframes scaleIn {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@keyframes pulse {
-  0%, 100% {
+  .site-nav[data-elevated='true']::after {
     opacity: 1;
   }
-  50% {
-    opacity: 0.5;
+
+  .page-shell {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 246, 248, 1) 60%);
+  }
+
+  .feature-grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+  }
+
+  @media (min-width: 768px) {
+    .feature-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .stat-icon {
+    display: grid;
+    place-items: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(145deg, rgba(29, 125, 140, 0.12), rgba(29, 125, 140, 0.28));
+    color: var(--color-accent-strong);
+  }
+
+  .faq-item {
+    border-radius: var(--radius);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-soft);
+    transition: box-shadow var(--transition), transform var(--transition);
+  }
+
+  .faq-item[open] {
+    box-shadow: var(--shadow-hover);
+    transform: translateY(-2px);
+  }
+
+  .faq-trigger {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.4rem 1.75rem;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--color-fg);
+    transition: color var(--transition);
+  }
+
+  .faq-trigger:hover {
+    color: var(--color-accent-strong);
+  }
+
+  .faq-content {
+    padding: 0 1.75rem 1.6rem;
+    color: var(--color-muted);
+  }
+
+  .timeline {
+    position: relative;
+    padding-left: 2.5rem;
+  }
+
+  .timeline::before {
+    content: '';
+    position: absolute;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    left: 1.15rem;
+    width: 2px;
+    background: var(--color-border);
+  }
+
+  .timeline-step {
+    position: relative;
+    padding: 1.5rem 1.75rem;
+    border-radius: var(--radius);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-soft);
+    transition: transform var(--transition), box-shadow var(--transition);
+  }
+
+  .timeline-step::before {
+    content: attr(data-step);
+    position: absolute;
+    left: -2.05rem;
+    top: 1.4rem;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: var(--color-accent);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+  }
+
+  .timeline-step:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-hover);
   }
 }
 
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-100%);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
   }
 }
 
-@keyframes countUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -1000px 0;
-  }
-  100% {
-    background-position: 1000px 0;
-  }
-}
-
-.animate-fadeIn {
-  animation: fadeIn 0.6s ease-out;
-}
-
-.animate-slideInLeft {
-  animation: slideInFromLeft 0.6s ease-out;
-}
-
-.animate-slideInRight {
-  animation: slideInFromRight 0.6s ease-out;
-}
-
-.animate-scaleIn {
-  animation: scaleIn 0.4s ease-out;
-}
-
-.animate-pulse-slow {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-}
-
-.animate-slideDown {
-  animation: slideDown 0.5s ease-out;
-}
-
-.animate-countUp {
-  animation: countUp 0.8s ease-out;
-}
-
-.animate-float {
-  animation: float 3s ease-in-out infinite;
-}
-
-/* Glow effect for buttons and cards */
-.glow-on-hover {
-  position: relative;
-  transition: all 0.3s ease;
-}
-
-.glow-on-hover::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  border-radius: inherit;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  background: linear-gradient(45deg, #3b82f6, #60a5fa, #3b82f6);
-  background-size: 200% 200%;
-  filter: blur(20px);
-  z-index: -1;
-}
-
-.glow-on-hover:hover::before {
-  opacity: 0.7;
-  animation: shimmer 2s linear infinite;
-}
-
-/* Smooth scroll */
-html {
-  scroll-behavior: smooth;
-}
-
-/* Ripple effect for buttons */
-@keyframes ripple {
-  0% {
-    transform: scale(0);
-    opacity: 0.5;
-  }
-  100% {
-    transform: scale(4);
-    opacity: 0;
-  }
-}
-
-/* Subtle shine effect */
-@keyframes shine {
-  0% {
-    left: -100%;
-  }
-  100% {
-    left: 100%;
-  }
-}
-
-.button-shine {
-  position: relative;
-  overflow: hidden;
-}
-
-.button-shine::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.3),
-    transparent
-  );
-  transition: left 0.5s;
-}
-
-.button-shine:hover::after {
-  left: 100%;
-}
-
-/* Focus states for accessibility */
 button:focus-visible,
-a:focus-visible {
-  outline: 2px solid #2563eb;
-  outline-offset: 2px;
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
 }
 
-/* Micro-interactions: Button Click Effect */
-.button-click {
-  transition: transform 0.1s ease;
+input,
+select,
+textarea {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  color: var(--color-fg);
+  transition: border var(--transition), box-shadow var(--transition), background var(--transition);
 }
 
-.button-click:active {
-  transform: scale(0.98);
+input::placeholder,
+textarea::placeholder {
+  color: color-mix(in srgb, var(--color-muted) 60%, white 40%);
 }
 
-/* Micro-interactions: Card Hover Lift */
-.card-lift {
-  transition: all 0.2s ease;
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px var(--color-accent-soft);
 }
 
-.card-lift:hover {
-  transform: translateY(-2px);
+label {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  letter-spacing: 0.01em;
 }
 
-/* Custom scrollbar */
-::-webkit-scrollbar {
-  width: 10px;
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
 }
 
-::-webkit-scrollbar-track {
-  background: #f1f5f9;
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
 }
 
-::-webkit-scrollbar-thumb {
-  background: #94a3b8;
-  border-radius: 5px;
+.table-wrapper th,
+.table-wrapper td {
+  padding: 0.9rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: #64748b;
+.table-wrapper th {
+  font-weight: 600;
+  color: var(--color-fg);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: var(--color-surface-muted);
+  color: var(--color-muted);
+}
+
+.badge-accent {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+
+/* Legacy utility color harmonization */
+.bg-blue-50,
+.bg-blue-100 {
+  background: color-mix(in srgb, var(--color-accent) 12%, white 88%) !important;
+}
+
+.text-blue-600,
+.text-blue-700 {
+  color: var(--color-accent-strong) !important;
+}
+
+.border-blue-500,
+.border-blue-600,
+.border-blue-200 {
+  border-color: color-mix(in srgb, var(--color-accent) 70%, transparent) !important;
+}
+
+.bg-green-50,
+.bg-green-100 {
+  background: color-mix(in srgb, var(--color-success) 15%, white 85%) !important;
+}
+
+.text-green-600,
+.text-green-800,
+.text-green-900 {
+  color: var(--color-success) !important;
+}
+
+.border-green-500,
+.border-green-300 {
+  border-color: color-mix(in srgb, var(--color-success) 65%, transparent) !important;
+}
+
+.bg-amber-50,
+.bg-yellow-50 {
+  background: color-mix(in srgb, var(--color-warning) 16%, white 84%) !important;
+}
+
+.text-amber-900,
+.text-yellow-800 {
+  color: var(--color-warning) !important;
+}
+
+.border-amber-500,
+.border-yellow-400 {
+  border-color: color-mix(in srgb, var(--color-warning) 65%, transparent) !important;
+}
+
+.bg-red-50 {
+  background: color-mix(in srgb, var(--color-danger) 14%, white 86%) !important;
+}
+
+.text-red-800,
+.text-red-900 {
+  color: var(--color-danger) !important;
+}
+
+.border-red-500 {
+  border-color: color-mix(in srgb, var(--color-danger) 65%, transparent) !important;
+}
+
+.bg-gray-50,
+.bg-gray-100 {
+  background: color-mix(in srgb, var(--color-muted) 10%, white 90%) !important;
+}
+
+.footer {
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border-top: 1px solid var(--color-border);
+}
+
+.footer__links a {
+  position: relative;
+  padding-block: 0.5rem;
+  font-weight: 500;
+  color: var(--color-muted);
+}
+
+.footer__links a:hover {
+  color: var(--color-fg);
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -368,13 +368,28 @@ textarea:focus-visible {
 input,
 select,
 textarea {
+  --input-padding-x: 1rem;
+  --input-padding-y: 0.85rem;
+  --input-padding-left: var(--input-padding-x);
+  --input-padding-right: var(--input-padding-x);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 0.85rem 1rem;
+  padding-block: var(--input-padding-y);
+  padding-inline: var(--input-padding-x);
+  padding-inline-start: var(--input-padding-left);
+  padding-inline-end: var(--input-padding-right);
   font-size: 1rem;
   color: var(--color-fg);
   transition: border var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.input-with-icon {
+  --input-padding-left: 3.25rem;
+}
+
+.input-with-unit {
+  --input-padding-right: 4.5rem;
 }
 
 input::placeholder,

--- a/app/tokens.css
+++ b/app/tokens.css
@@ -1,0 +1,42 @@
+:root {
+  color-scheme: light;
+  --color-bg: #f4f6f8;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f0f3f6;
+  --color-fg: #1f2430;
+  --color-muted: #5b6473;
+  --color-border: rgba(31, 36, 48, 0.12);
+  --color-border-strong: rgba(31, 36, 48, 0.18);
+  --color-accent: #1d7d8c;
+  --color-accent-soft: rgba(29, 125, 140, 0.14);
+  --color-accent-strong: #166774;
+  --color-success: #2b8a5b;
+  --color-warning: #b35a1f;
+  --color-danger: #b63d3d;
+  --shadow-soft: 0 18px 48px -28px rgba(18, 24, 32, 0.35);
+  --shadow-hover: 0 22px 40px -24px rgba(18, 24, 32, 0.4);
+  --radius: 18px;
+  --radius-sm: 12px;
+  --radius-lg: 24px;
+  --container-w: 72rem;
+  --transition: 180ms ease;
+  --transition-slow: 280ms ease;
+  --font-sans: 'Inter', 'Segoe UI', 'Helvetica Neue', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-heading: 'Manrope', 'Inter', 'Segoe UI', 'Helvetica Neue', system-ui, sans-serif;
+}
+
+html.dark {
+  color-scheme: dark;
+  --color-bg: #101418;
+  --color-surface: #181e25;
+  --color-surface-muted: #1e252d;
+  --color-fg: #f3f5f7;
+  --color-muted: #b0b8c3;
+  --color-border: rgba(240, 244, 248, 0.12);
+  --color-border-strong: rgba(240, 244, 248, 0.2);
+  --color-accent: #3aa7ba;
+  --color-accent-soft: rgba(58, 167, 186, 0.24);
+  --color-accent-strong: #2b7f8c;
+  --shadow-soft: 0 26px 60px -34px rgba(0, 0, 0, 0.65);
+  --shadow-hover: 0 30px 70px -32px rgba(0, 0, 0, 0.7);
+}

--- a/app/utils/poi-checker.ts
+++ b/app/utils/poi-checker.ts
@@ -1,6 +1,6 @@
 // POI-Analyse und Risikobewertung für Betriebsanlagengenehmigung
 
-import type { POI, Address } from '@/app/lib/viennagis-api';
+import type { POI } from '@/app/lib/viennagis-api';
 
 export interface RiskAssessment {
   riskPoints: number; // 0-100
@@ -19,7 +19,7 @@ export interface RiskAssessment {
 /**
  * POIs analysieren und Risikobewertung erstellen
  */
-export function analyzePOIs(pois: POI[], address: Address): RiskAssessment {
+export function analyzePOIs(pois: POI[]): RiskAssessment {
   let riskPoints = 0;
   const warnings: string[] = [];
   const recommendations: string[] = [];


### PR DESCRIPTION
## Summary
- add design tokens and global utility classes to align typography, spacing, and surfaces
- restyle navigation, home sections, address checker, FAQ, and document cards with the new neutral + accent palette
- document the refreshed design system in DESIGN_OVERVIEW.md for future updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690928382228832b9797e9b6f4b28137