### PR TITLE
Improve text wrapping and responsive layouts

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -8,6 +8,8 @@ import { useParams } from "next/navigation";
 import AnimatedStats from "../components/AnimatedStats";
 import { defaultLocale } from "@/i18n";
 import { CheckCircle2, FileText, Zap, Languages, Shield, ArrowRight, Sparkles } from "lucide-react";
+import BreakText from "@/components/ui/BreakText";
+import AutoGrid from "@/components/ui/AutoGrid";
 
 // Displays the localized homepage with locale-aware navigation targets.
 export default function Home() {
@@ -70,24 +72,26 @@ export default function Home() {
         <div className="site-container">
           <section className="section page-hero">
             <h1 className="page-hero__title">
-              <span>{t("title")}</span>
+              <BreakText className="block">{t("title")}</BreakText>
             </h1>
-            <p className="page-hero__copy">{t("subtitle")}</p>
+            <BreakText className="page-hero__copy block">{t("subtitle")}</BreakText>
           </section>
 
           <section className="section section--compact">
-            <div className="card-grid card-grid--two page-actions">
+            <AutoGrid min="16rem" className="page-actions">
               <article className="card">
                 <div className="card__icon">
                   <CheckCircle2 className="w-7 h-7" strokeWidth={2.2} />
                 </div>
-                <h2 className="card__title">{t("card1Title")}</h2>
-                <p className="card__body">{t("card1Description")}</p>
+                <h2 className="card__title">
+                  <BreakText className="block">{t("card1Title")}</BreakText>
+                </h2>
+                <BreakText className="card__body block">{t("card1Description")}</BreakText>
                 <Link
                   href={`/${activeLocale}/check`}
                   className="btn btn-primary w-full justify-center"
                 >
-                  {t("card1Button")}
+                  <BreakText>{t("card1Button")}</BreakText>
                   <ArrowRight className="w-5 h-5" />
                 </Link>
               </article>
@@ -96,17 +100,19 @@ export default function Home() {
                 <div className="card__icon card__icon--warm">
                   <FileText className="w-7 h-7" strokeWidth={2.2} />
                 </div>
-                <h2 className="card__title">{t("card2Title")}</h2>
-                <p className="card__body">{t("card2Description")}</p>
+                <h2 className="card__title">
+                  <BreakText className="block">{t("card2Title")}</BreakText>
+                </h2>
+                <BreakText className="card__body block">{t("card2Description")}</BreakText>
                 <Link
                   href={`/${activeLocale}/dokumente`}
                   className="btn btn-secondary w-full justify-center"
                 >
-                  {t("card2Button")}
+                  <BreakText>{t("card2Button")}</BreakText>
                   <ArrowRight className="w-5 h-5" />
                 </Link>
               </article>
-            </div>
+            </AutoGrid>
           </section>
 
           <section className="section section--compact">
@@ -138,80 +144,102 @@ export default function Home() {
 
           <section className="section">
             <div className="section__heading">
-              <h2>{t("seo.heading")}</h2>
-              <p className="section__copy">{t("seo.intro")}</p>
+              <h2>
+                <BreakText className="block">{t("seo.heading")}</BreakText>
+              </h2>
+              <BreakText className="section__copy block">{t("seo.intro")}</BreakText>
             </div>
 
-            <div className="card-grid card-grid--three mt-12">
+            <AutoGrid min="14rem" className="mt-12">
               <article className="card card--subtle">
                 <div className="card__icon card__icon--accent-soft">
                   <Zap className="w-6 h-6" strokeWidth={2} />
                 </div>
-                <h3 className="card__title">{t("seo.feature1Title")}</h3>
-                <p className="card__body">{t("seo.feature1Text")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("seo.feature1Title")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("seo.feature1Text")}</BreakText>
               </article>
 
               <article className="card card--subtle">
                 <div className="card__icon card__icon--success">
                   <Languages className="w-6 h-6" strokeWidth={2} />
                 </div>
-                <h3 className="card__title">{t("seo.feature2Title")}</h3>
-                <p className="card__body">{t("seo.feature2Text")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("seo.feature2Title")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("seo.feature2Text")}</BreakText>
               </article>
 
               <article className="card card--subtle">
                 <div className="card__icon card__icon--shield">
                   <Shield className="w-6 h-6" strokeWidth={2} />
                 </div>
-                <h3 className="card__title">{t("seo.feature3Title")}</h3>
-                <p className="card__body">{t("seo.feature3Text")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("seo.feature3Title")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("seo.feature3Text")}</BreakText>
               </article>
-            </div>
+            </AutoGrid>
 
             <div className="surface-muted mt-12 flex flex-col gap-6 md:flex-row md:items-center">
               <div className="card__icon">
                 <Sparkles className="w-6 h-6" strokeWidth={2} />
               </div>
               <div className="flex-1 space-y-3">
-                <h3 className="card__title">{t("seo.whyTitle")}</h3>
-                <p className="card__body text-lg">{t("seo.whyText")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("seo.whyTitle")}</BreakText>
+                </h3>
+                <BreakText className="card__body text-lg block">{t("seo.whyText")}</BreakText>
               </div>
             </div>
           </section>
 
           <section className="section">
             <div className="section__heading">
-              <h2>{t("gruender.heading")}</h2>
-              <p className="section__copy">{t("gruender.intro")}</p>
+              <h2>
+                <BreakText className="block">{t("gruender.heading")}</BreakText>
+              </h2>
+              <BreakText className="section__copy block">{t("gruender.intro")}</BreakText>
             </div>
 
-            <div className="card-grid card-grid--two mt-12">
+            <AutoGrid min="16rem" className="mt-12">
               <article className="card card--subtle">
-                <h3 className="card__title">{t("gruender.question1")}</h3>
-                <p className="card__body">{t("gruender.answer1")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("gruender.question1")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("gruender.answer1")}</BreakText>
               </article>
 
               <article className="card card--subtle">
-                <h3 className="card__title">{t("gruender.question2")}</h3>
-                <p className="card__body">{t("gruender.answer2")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("gruender.question2")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("gruender.answer2")}</BreakText>
               </article>
 
               <article className="card card--subtle">
-                <h3 className="card__title">{t("gruender.question3")}</h3>
-                <p className="card__body">{t("gruender.answer3")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("gruender.question3")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("gruender.answer3")}</BreakText>
               </article>
 
               <article className="card card--subtle">
-                <h3 className="card__title">{t("gruender.question4")}</h3>
-                <p className="card__body">{t("gruender.answer4")}</p>
+                <h3 className="card__title">
+                  <BreakText className="block">{t("gruender.question4")}</BreakText>
+                </h3>
+                <BreakText className="card__body block">{t("gruender.answer4")}</BreakText>
               </article>
-            </div>
+            </AutoGrid>
 
             <div className="cta-panel">
-              <h3>{t("gruender.ctaTitle")}</h3>
-              <p>{t("gruender.ctaText")}</p>
+              <h3>
+                <BreakText className="block">{t("gruender.ctaTitle")}</BreakText>
+              </h3>
+              <BreakText className="block">{t("gruender.ctaText")}</BreakText>
               <Link href={`/${activeLocale}/check`} className="btn btn-primary">
-                {t("card1Button")}
+                <BreakText>{t("card1Button")}</BreakText>
                 <ArrowRight className="w-5 h-5" />
               </Link>
             </div>

--- a/app/components/AddressChecker.tsx
+++ b/app/components/AddressChecker.tsx
@@ -8,6 +8,8 @@ import { analyzePOIs, type RiskAssessment as RiskAssessmentType } from '@/app/ut
 import POIList from './POIList';
 import RiskAssessment from './RiskAssessment';
 import ViennaGISMap from './ViennaGISMap';
+import AutoGrid from '@/components/ui/AutoGrid';
+import BreakText from '@/components/ui/BreakText';
 
 export default function AddressChecker() {
   const t = useTranslations('addressChecker');
@@ -112,12 +114,12 @@ export default function AddressChecker() {
       {/* Suchformular */}
       <div className="bg-white rounded-xl shadow-md p-6 md:p-8">
         <form onSubmit={handleSearch} className="space-y-4">
-          <div>
-            <label htmlFor="address-input" className="block text-sm font-semibold text-gray-700 mb-2">
-              {t('search.label')}
+          <div className="space-y-3">
+            <label htmlFor="address-input" className="block text-sm font-semibold text-gray-700">
+              <BreakText>{t('search.label')}</BreakText>
             </label>
-            <div className="flex gap-3">
-              <div className="flex-1 relative">
+            <AutoGrid min="18rem" className="items-start">
+              <div className="relative min-w-0">
                 <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <input
                   id="address-input"
@@ -146,21 +148,23 @@ export default function AddressChecker() {
                   </>
                 )}
               </button>
-            </div>
+            </AutoGrid>
           </div>
         </form>
 
         {/* Fehleranzeige */}
         {error && (
           <div className="mt-4 p-4 bg-red-50 border-l-4 border-red-500 rounded-r-lg">
-            <p className="text-red-800 font-medium">{error}</p>
+            <BreakText className="text-red-800 font-medium block">{error}</BreakText>
           </div>
         )}
 
         {/* Mehrere Suchergebnisse */}
         {searchResults.length > 1 && (
           <div className="mt-6">
-            <h3 className="font-bold text-gray-900 mb-3">{t('search.multipleResults')}</h3>
+            <h3 className="font-bold text-gray-900 mb-3 min-w-0">
+              <BreakText className="block">{t('search.multipleResults')}</BreakText>
+            </h3>
             <ul className="space-y-2">
               {searchResults.map((result, index) => (
                 <li key={index}>
@@ -168,9 +172,11 @@ export default function AddressChecker() {
                     onClick={() => handleSelectAddress(result)}
                     className="w-full text-left p-4 border-2 border-gray-200 hover:border-blue-500 hover:bg-blue-50 rounded-lg transition-all"
                   >
-                    <div className="font-medium text-gray-900">{result.fullAddress}</div>
-                    <div className="text-sm text-gray-600">
-                      {result.postalCode} {result.district}
+                    <div className="font-medium text-gray-900 min-w-0">
+                      <BreakText className="block">{result.fullAddress}</BreakText>
+                    </div>
+                    <div className="text-sm text-gray-600 min-w-0">
+                      <BreakText className="block">{result.postalCode} {result.district}</BreakText>
                     </div>
                   </button>
                 </li>
@@ -185,20 +191,20 @@ export default function AddressChecker() {
         <>
           {/* Ausgewählte Adresse */}
           <div className="bg-white rounded-xl shadow-md p-6">
-            <div className="flex items-start justify-between">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 mb-1">
-                  {selectedAddress.fullAddress}
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h2 className="text-xl font-bold text-gray-900 mb-1 min-w-0">
+                  <BreakText className="block">{selectedAddress.fullAddress}</BreakText>
                 </h2>
-                <p className="text-gray-600">
+                <BreakText className="text-gray-600 block">
                   {selectedAddress.postalCode} Wien, {selectedAddress.district}. Bezirk
-                </p>
+                </BreakText>
               </div>
               <button
                 onClick={handleReset}
                 className="px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg font-medium transition-colors"
               >
-                {t('actions.newCheck')}
+                <BreakText>{t('actions.newCheck')}</BreakText>
               </button>
             </div>
           </div>
@@ -233,34 +239,33 @@ export default function AddressChecker() {
                 <span>500m</span>
               </div>
 
-              <p className="text-sm text-gray-600">
-                Zeigt kritische Einrichtungen im Umkreis von {searchRadius} Metern an.
-                Größerer Radius = mehr POIs, umfassendere Analyse.
-              </p>
+              <BreakText className="text-sm text-gray-600 block">
+                Zeigt kritische Einrichtungen im Umkreis von {searchRadius} Metern an. Größerer Radius = mehr POIs, umfassendere Analyse.
+              </BreakText>
             </div>
           </div>
 
           {/* POI-Liste und Karte Grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <AutoGrid min="20rem" className="gap-6">
             {/* POI-Liste */}
             <div className="bg-white rounded-xl shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                {t('pois.title')}
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 min-w-0">
+                <BreakText className="block">{t('pois.title')}</BreakText>
               </h2>
               <POIList pois={nearbyPOIs} />
             </div>
 
             {/* Karte */}
             <div className="bg-white rounded-xl shadow-md p-6">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
-                {t('map.title')}
+              <h2 className="text-2xl font-bold text-gray-900 mb-4 min-w-0">
+                <BreakText className="block">{t('map.title')}</BreakText>
               </h2>
               <ViennaGISMap address={selectedAddress} pois={nearbyPOIs} />
-              <p className="text-xs text-gray-500 mt-2">
+              <BreakText className="text-xs text-gray-500 mt-2 block">
                 {t('map.attribution')}
-              </p>
+              </BreakText>
             </div>
-          </div>
+          </AutoGrid>
 
           {/* Risikobewertung */}
           {riskAssessment && (
@@ -273,7 +278,7 @@ export default function AddressChecker() {
       {selectedAddress && loading && (
         <div className="bg-white rounded-xl shadow-md p-12 text-center">
           <Loader2 className="w-12 h-12 animate-spin mx-auto mb-4 text-blue-600" />
-          <p className="text-gray-600">Analysiere Umgebung...</p>
+          <BreakText className="text-gray-600 block">Analysiere Umgebung...</BreakText>
         </div>
       )}
     </div>

--- a/app/components/Documents/DocumentCard.tsx
+++ b/app/components/Documents/DocumentCard.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import type { Document } from '@/app/config/documents';
 import { Download, ExternalLink, FileText } from 'lucide-react';
+import BreakText from '@/components/ui/BreakText';
 
 interface DocumentCardProps {
   document: Document;
@@ -35,13 +36,13 @@ export default function DocumentCard({ document, language }: DocumentCardProps) 
 
       {/* Content */}
       <div className="p-5">
-        <h3 className="text-lg font-bold mb-2 text-gray-900">
-          {translation.title}
+        <h3 className="text-lg font-bold mb-2 text-gray-900 min-w-0">
+          <BreakText className="block">{translation.title}</BreakText>
         </h3>
 
-        <p className="text-sm text-gray-600 mb-4 line-clamp-3">
+        <BreakText className="block text-sm text-gray-600 mb-4 line-clamp-3">
           {translation.description}
-        </p>
+        </BreakText>
 
         {/* Metadata */}
         <div className="flex items-center gap-4 text-xs text-gray-500 mb-4 pb-4 border-b border-gray-100">

--- a/app/components/FormularAssistent/FormularWizard.tsx
+++ b/app/components/FormularAssistent/FormularWizard.tsx
@@ -11,6 +11,7 @@ import SchrittFlaechen from './schritte/SchrittFlaechen';
 import SchrittZusammenfassung from './schritte/SchrittZusammenfassung';
 import { generiereEinfachesPDF } from './PDFGenerator';
 import type { FormularDaten } from './types';
+import BreakText from '@/components/ui/BreakText';
 
 const SCHRITTE = [
   { id: 'antragsteller', icon: '👤' },
@@ -142,20 +143,20 @@ export default function FormularWizard() {
     <div className="max-w-5xl mx-auto">
       {/* Header */}
       <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-6">
-        <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
-          {t('titel')}
+        <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3 min-w-0">
+          <BreakText className="block">{t('titel')}</BreakText>
         </h1>
-        <p className="text-gray-600 mb-4">
+        <BreakText className="block text-gray-600 mb-4">
           {t('beschreibung')}
-        </p>
+        </BreakText>
 
         {/* Disclaimer */}
         <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded-r-lg">
-          <div className="flex items-start gap-3">
+          <div className="flex items-start gap-3 min-w-0">
             <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-            <p className="text-sm text-amber-900">
+            <BreakText className="text-sm text-amber-900 block">
               {t('disclaimer')}
-            </p>
+            </BreakText>
           </div>
         </div>
       </div>
@@ -210,24 +211,24 @@ export default function FormularWizard() {
 
       {/* Navigation */}
       <div className="bg-white rounded-xl shadow-lg p-6 flex flex-col sm:flex-row gap-4 justify-between items-center">
-        <div className="flex gap-3">
+        <div className="flex gap-3 min-w-0">
           <button
             onClick={handleEntwurfSpeichern}
             className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg font-medium transition-colors"
           >
             <Save className="w-4 h-4" />
-            {t('entwurfSpeichern')}
+            <BreakText>{t('entwurfSpeichern')}</BreakText>
           </button>
         </div>
 
-        <div className="flex gap-3">
+        <div className="flex gap-3 flex-wrap justify-center sm:justify-end min-w-0">
           {aktuellerSchritt > 0 && (
             <button
               onClick={vorherigerSchritt}
               className="inline-flex items-center gap-2 px-6 py-3 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg font-semibold transition-colors"
             >
               <ChevronLeft className="w-5 h-5" />
-              {t('zurueck')}
+              <BreakText>{t('zurueck')}</BreakText>
             </button>
           )}
 
@@ -237,7 +238,7 @@ export default function FormularWizard() {
               disabled={!istSchrittValid()}
               className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white rounded-lg font-semibold transition-colors"
             >
-              {t('weiter')}
+              <BreakText>{t('weiter')}</BreakText>
               <ChevronRight className="w-5 h-5" />
             </button>
           ) : (
@@ -246,7 +247,7 @@ export default function FormularWizard() {
               className="inline-flex items-center gap-2 px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg font-semibold transition-colors"
             >
               <FileDown className="w-5 h-5" />
-              {t('pdfErstellen')}
+              <BreakText>{t('pdfErstellen')}</BreakText>
             </button>
           )}
         </div>

--- a/app/components/FormularAssistent/schritte/SchrittAntragsteller.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittAntragsteller.tsx
@@ -2,6 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 import { User, Phone, Mail, Users } from 'lucide-react';
+import AutoGrid from '@/components/ui/AutoGrid';
+import BreakText from '@/components/ui/BreakText';
 import type { FormularDaten } from '../types';
 
 interface SchrittAntragstellerProps {
@@ -20,95 +22,107 @@ export default function SchrittAntragsteller({ daten, onChange }: SchrittAntrags
           <User className="w-6 h-6 text-blue-600" />
         </div>
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{t('titel')}</h2>
-          <p className="text-gray-600">{t('beschreibung')}</p>
+          <h2 className="text-2xl font-bold text-gray-900 min-w-0">
+            <BreakText className="block">{t('titel')}</BreakText>
+          </h2>
+          <BreakText className="block text-gray-600">{t('beschreibung')}</BreakText>
         </div>
       </div>
 
-      {/* Name und Anschrift */}
-      <div>
-        <label htmlFor="name" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.name.label')} <span className="text-red-500">*</span>
-        </label>
-        <div className="relative">
-          <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            id="name"
-            type="text"
-            value={daten.name}
-            onChange={(e) => onChange('name', e.target.value)}
-            placeholder={t('felder.name.platzhalter')}
-            className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-            required
-          />
+      <AutoGrid min="18rem" className="gap-y-6">
+        {/* Name und Anschrift */}
+        <div className="min-w-0">
+          <label htmlFor="name" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.name.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <div className="relative">
+            <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              id="name"
+              type="text"
+              value={daten.name}
+              onChange={(e) => onChange('name', e.target.value)}
+              placeholder={t('felder.name.platzhalter')}
+              className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+              required
+            />
+          </div>
+          <BreakText className="mt-1.5 block text-sm text-gray-600">
+            {t('felder.name.hilfe')}
+          </BreakText>
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
-          {t('felder.name.hilfe')}
-        </p>
-      </div>
 
-      {/* Kontaktperson */}
-      <div>
-        <label htmlFor="kontaktperson" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.kontaktperson.label')} <span className="text-red-500">*</span>
-        </label>
-        <div className="relative">
-          <Users className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            id="kontaktperson"
-            type="text"
-            value={daten.kontaktperson}
-            onChange={(e) => onChange('kontaktperson', e.target.value)}
-            placeholder={t('felder.kontaktperson.platzhalter')}
-            className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-            required
-          />
+        {/* Kontaktperson */}
+        <div className="min-w-0">
+          <label htmlFor="kontaktperson" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.kontaktperson.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <div className="relative">
+            <Users className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              id="kontaktperson"
+              type="text"
+              value={daten.kontaktperson}
+              onChange={(e) => onChange('kontaktperson', e.target.value)}
+              placeholder={t('felder.kontaktperson.platzhalter')}
+              className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+              required
+            />
+          </div>
+          <BreakText className="mt-1.5 block text-sm text-gray-600">
+            {t('felder.kontaktperson.hilfe')}
+          </BreakText>
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
-          {t('felder.kontaktperson.hilfe')}
-        </p>
-      </div>
 
-      {/* Telefon */}
-      <div>
-        <label htmlFor="telefon" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.telefon.label')} <span className="text-red-500">*</span>
-        </label>
-        <div className="relative">
-          <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            id="telefon"
-            type="tel"
-            value={daten.telefon}
-            onChange={(e) => onChange('telefon', e.target.value)}
-            placeholder={t('felder.telefon.platzhalter')}
-            className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-            required
-          />
+        {/* Telefon */}
+        <div className="min-w-0">
+          <label htmlFor="telefon" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.telefon.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <div className="relative">
+            <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              id="telefon"
+              type="tel"
+              value={daten.telefon}
+              onChange={(e) => onChange('telefon', e.target.value)}
+              placeholder={t('felder.telefon.platzhalter')}
+              className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+              required
+            />
+          </div>
         </div>
-      </div>
 
-      {/* Email */}
-      <div>
-        <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.email.label')} <span className="text-red-500">*</span>
-        </label>
-        <div className="relative">
-          <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            id="email"
-            type="email"
-            value={daten.email}
-            onChange={(e) => onChange('email', e.target.value)}
-            placeholder={t('felder.email.platzhalter')}
-            className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-            required
-          />
+        {/* Email */}
+        <div className="min-w-0">
+          <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.email.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <div className="relative">
+            <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              id="email"
+              type="email"
+              value={daten.email}
+              onChange={(e) => onChange('email', e.target.value)}
+              placeholder={t('felder.email.platzhalter')}
+              className="input-with-icon w-full border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+              required
+            />
+          </div>
+          <BreakText className="mt-1.5 block text-sm text-gray-600">
+            {t('felder.email.hilfe')}
+          </BreakText>
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
-          {t('felder.email.hilfe')}
-        </p>
-      </div>
+      </AutoGrid>
     </div>
   );
 }

--- a/app/components/FormularAssistent/schritte/SchrittAntragstyp.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittAntragstyp.tsx
@@ -2,6 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 import { FileText, Factory, RefreshCw } from 'lucide-react';
+import AutoGrid from '@/components/ui/AutoGrid';
+import BreakText from '@/components/ui/BreakText';
 import type { FormularDaten } from '../types';
 
 interface SchrittAntragstyppProps {
@@ -20,17 +22,21 @@ export default function SchrittAntragstyp({ daten, onChange }: SchrittAntragstyp
           <FileText className="w-6 h-6 text-blue-600" />
         </div>
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{t('titel')}</h2>
-          <p className="text-gray-600">{t('beschreibung')}</p>
+          <h2 className="text-2xl font-bold text-gray-900 min-w-0">
+            <BreakText className="block">{t('titel')}</BreakText>
+          </h2>
+          <BreakText className="block text-gray-600">{t('beschreibung')}</BreakText>
         </div>
       </div>
 
       {/* Typ: Neu oder Änderung */}
       <div>
         <label className="block text-sm font-semibold text-gray-700 mb-3">
-          {t('felder.typ.label')} <span className="text-red-500">*</span>
+          <BreakText>
+            {t('felder.typ.label')} <span className="text-red-500">*</span>
+          </BreakText>
         </label>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <AutoGrid min="18rem" className="gap-y-4">
           {/* Neu */}
           <button
             type="button"
@@ -49,13 +55,13 @@ export default function SchrittAntragstyp({ daten, onChange }: SchrittAntragstyp
                   <Factory className="w-5 h-5" />
                 </div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <div className="font-semibold text-gray-900 mb-1">
-                  {t('felder.typ.optionen.neu.label')}
+                  <BreakText className="block">{t('felder.typ.optionen.neu.label')}</BreakText>
                 </div>
-                <div className="text-sm text-gray-600">
+                <BreakText className="block text-sm text-gray-600">
                   {t('felder.typ.optionen.neu.beschreibung')}
-                </div>
+                </BreakText>
               </div>
             </div>
           </button>
@@ -78,23 +84,25 @@ export default function SchrittAntragstyp({ daten, onChange }: SchrittAntragstyp
                   <RefreshCw className="w-5 h-5" />
                 </div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <div className="font-semibold text-gray-900 mb-1">
-                  {t('felder.typ.optionen.aenderung.label')}
+                  <BreakText className="block">{t('felder.typ.optionen.aenderung.label')}</BreakText>
                 </div>
-                <div className="text-sm text-gray-600">
+                <BreakText className="block text-sm text-gray-600">
                   {t('felder.typ.optionen.aenderung.beschreibung')}
-                </div>
+                </BreakText>
               </div>
             </div>
           </button>
-        </div>
+        </AutoGrid>
       </div>
 
       {/* Art der Anlage */}
       <div>
         <label htmlFor="art_der_anlage" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.art.label')} <span className="text-red-500">*</span>
+          <BreakText>
+            {t('felder.art.label')} <span className="text-red-500">*</span>
+          </BreakText>
         </label>
         <input
           id="art_der_anlage"
@@ -105,15 +113,17 @@ export default function SchrittAntragstyp({ daten, onChange }: SchrittAntragstyp
           className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
           required
         />
-        <p className="mt-1.5 text-sm text-gray-600">
+        <BreakText className="mt-1.5 block text-sm text-gray-600">
           {t('felder.art.hilfe')}
-        </p>
+        </BreakText>
       </div>
 
       {/* Anlagenteile und Tätigkeiten */}
       <div>
         <label htmlFor="anlagenteile" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.anlagenteile.label')} <span className="text-red-500">*</span>
+          <BreakText>
+            {t('felder.anlagenteile.label')} <span className="text-red-500">*</span>
+          </BreakText>
         </label>
         <textarea
           id="anlagenteile"
@@ -124,9 +134,9 @@ export default function SchrittAntragstyp({ daten, onChange }: SchrittAntragstyp
           className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all resize-none"
           required
         />
-        <p className="mt-1.5 text-sm text-gray-600">
+        <BreakText className="mt-1.5 block text-sm text-gray-600">
           {t('felder.anlagenteile.hilfe')}
-        </p>
+        </BreakText>
       </div>
     </div>
   );

--- a/app/components/FormularAssistent/schritte/SchrittFlaechen.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittFlaechen.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { Ruler, Zap } from 'lucide-react';
+import BreakText from '@/components/ui/BreakText';
 import type { FormularDaten } from '../types';
 
 interface SchrittFlaechenProps {
@@ -20,15 +21,19 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
           <Ruler className="w-6 h-6 text-blue-600" />
         </div>
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{t('titel')}</h2>
-          <p className="text-gray-600">{t('beschreibung')}</p>
+          <h2 className="text-2xl font-bold text-gray-900 min-w-0">
+            <BreakText className="block">{t('titel')}</BreakText>
+          </h2>
+          <BreakText className="block text-gray-600">{t('beschreibung')}</BreakText>
         </div>
       </div>
 
       {/* Beschreibung aller Flächen */}
       <div>
         <label htmlFor="flaechen_beschreibung" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.beschreibung.label')} <span className="text-red-500">*</span>
+          <BreakText>
+            {t('felder.beschreibung.label')} <span className="text-red-500">*</span>
+          </BreakText>
         </label>
         <textarea
           id="flaechen_beschreibung"
@@ -39,15 +44,17 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
           className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all resize-none font-mono text-sm"
           required
         />
-        <p className="mt-1.5 text-sm text-gray-600">
+        <BreakText className="mt-1.5 block text-sm text-gray-600">
           {t('felder.beschreibung.hilfe')}
-        </p>
+        </BreakText>
       </div>
 
       {/* Gesamtfläche */}
       <div>
         <label htmlFor="gesamtflaeche" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.gesamtflaeche.label')} <span className="text-red-500">*</span>
+          <BreakText>
+            {t('felder.gesamtflaeche.label')} <span className="text-red-500">*</span>
+          </BreakText>
         </label>
         <div className="relative">
           <input
@@ -64,15 +71,17 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
             m²
           </div>
         </div>
-        <p className="mt-1.5 text-sm text-gray-600">
+        <BreakText className="mt-1.5 block text-sm text-gray-600">
           {t('felder.gesamtflaeche.hilfe')}
-        </p>
+        </BreakText>
       </div>
 
       {/* Anschlussleistung */}
       <div>
         <label className="block text-sm font-semibold text-gray-700 mb-3">
-          {t('felder.anschlussleistung.label')} <span className="text-red-500">*</span>
+          <BreakText>
+            {t('felder.anschlussleistung.label')} <span className="text-red-500">*</span>
+          </BreakText>
         </label>
         <div className="space-y-3">
           {/* Unter 300 kW */}
@@ -85,16 +94,16 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
                 : 'border-gray-300 hover:border-green-300'
             }`}
           >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
                 <Zap className={`w-5 h-5 ${daten.anschlussleistung === 'unter300' ? 'text-green-600' : 'text-gray-400'}`} />
-                <div>
+                <div className="min-w-0">
                   <div className="font-semibold text-gray-900">
-                    {t('felder.anschlussleistung.optionen.unter300.label')}
+                    <BreakText className="block">{t('felder.anschlussleistung.optionen.unter300.label')}</BreakText>
                   </div>
-                  <div className="text-sm text-gray-600">
+                  <BreakText className="block text-sm text-gray-600">
                     {t('felder.anschlussleistung.optionen.unter300.info')}
-                  </div>
+                  </BreakText>
                 </div>
               </div>
               {daten.anschlussleistung === 'unter300' && (
@@ -117,16 +126,16 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
                 : 'border-gray-300 hover:border-amber-300'
             }`}
           >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
                 <Zap className={`w-5 h-5 ${daten.anschlussleistung === 'ueber300' ? 'text-amber-600' : 'text-gray-400'}`} />
-                <div>
+                <div className="min-w-0">
                   <div className="font-semibold text-gray-900">
-                    {t('felder.anschlussleistung.optionen.ueber300.label')}
+                    <BreakText className="block">{t('felder.anschlussleistung.optionen.ueber300.label')}</BreakText>
                   </div>
-                  <div className="text-sm text-gray-600">
+                  <BreakText className="block text-sm text-gray-600">
                     {t('felder.anschlussleistung.optionen.ueber300.info')}
-                  </div>
+                  </BreakText>
                 </div>
               </div>
               {daten.anschlussleistung === 'ueber300' && (
@@ -149,12 +158,12 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
                 : 'border-gray-300 hover:border-gray-400'
             }`}
           >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
                 <Zap className={`w-5 h-5 ${daten.anschlussleistung === 'keine' ? 'text-gray-600' : 'text-gray-400'}`} />
-                <div>
+                <div className="min-w-0">
                   <div className="font-semibold text-gray-900">
-                    {t('felder.anschlussleistung.optionen.keine.label')}
+                    <BreakText className="block">{t('felder.anschlussleistung.optionen.keine.label')}</BreakText>
                   </div>
                 </div>
               </div>
@@ -168,9 +177,9 @@ export default function SchrittFlaechen({ daten, onChange }: SchrittFlaechenProp
             </div>
           </button>
         </div>
-        <p className="mt-3 text-sm text-gray-600">
+        <BreakText className="mt-3 block text-sm text-gray-600">
           {t('felder.anschlussleistung.hilfe')}
-        </p>
+        </BreakText>
       </div>
     </div>
   );

--- a/app/components/FormularAssistent/schritte/SchrittStandort.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittStandort.tsx
@@ -9,6 +9,8 @@ import type { FormularDaten } from '../types';
 import type { Address } from '@/app/lib/viennagis-api';
 import ViennaGISMap from '@/app/components/ViennaGISMap';
 import POIList from '@/app/components/POIList';
+import AutoGrid from '@/components/ui/AutoGrid';
+import BreakText from '@/components/ui/BreakText';
 
 interface SchrittStandortProps {
   daten: FormularDaten;
@@ -72,35 +74,37 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
           <MapPin className="w-6 h-6 text-blue-600" />
         </div>
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{t('titel')}</h2>
-          <p className="text-gray-600">{t('beschreibung')}</p>
+          <h2 className="text-2xl font-bold text-gray-900 min-w-0">
+            <BreakText className="block">{t('titel')}</BreakText>
+          </h2>
+          <BreakText className="block text-gray-600">{t('beschreibung')}</BreakText>
         </div>
       </div>
 
       {/* Adresssuche */}
       <div className="bg-blue-50 border-2 border-blue-200 rounded-lg p-4">
-        <h3 className="font-semibold text-blue-900 mb-3 flex items-center gap-2">
+        <h3 className="font-semibold text-blue-900 mb-3 flex items-center gap-2 min-w-0">
           <Search className="w-5 h-5" />
-          {t('adresssuche.titel')}
+          <BreakText>{t('adresssuche.titel')}</BreakText>
         </h3>
-        <div className="flex gap-2">
+        <AutoGrid min="18rem" className="items-start">
           <input
             type="text"
             value={adresssuche}
             onChange={(e) => setAdresssuche(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && handleAdresssuche()}
             placeholder={t('adresssuche.platzhalter')}
-            className="flex-1 px-4 py-2 border-2 border-blue-300 rounded-lg focus:border-blue-500 outline-none"
+            className="w-full px-4 py-2 border-2 border-blue-300 rounded-lg focus:border-blue-500 outline-none"
           />
           <button
             onClick={handleAdresssuche}
             disabled={loading}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white rounded-lg font-medium transition-colors flex items-center gap-2 justify-center"
           >
             {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <Search className="w-5 h-5" />}
-            {t('adresssuche.button')}
+            <BreakText>{t('adresssuche.button')}</BreakText>
           </button>
-        </div>
+        </AutoGrid>
 
         {/* Suchergebnisse */}
         {suchergebnisse.length > 0 && (
@@ -111,69 +115,81 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
                 onClick={() => handleAdresseAuswaehlen(result)}
                 className="w-full text-left p-3 bg-white border-2 border-blue-200 hover:border-blue-500 hover:bg-blue-50 rounded-lg transition-all"
               >
-                <div className="font-medium text-gray-900">{result.fullAddress}</div>
-                <div className="text-sm text-gray-600">{result.postalCode} {result.district}</div>
+                <div className="font-medium text-gray-900 min-w-0">
+                  <BreakText className="block">{result.fullAddress}</BreakText>
+                </div>
+                <div className="text-sm text-gray-600 min-w-0">
+                  <BreakText className="block">{result.postalCode} {result.district}</BreakText>
+                </div>
               </button>
             ))}
           </div>
         )}
       </div>
 
-      {/* Bezirk */}
-      <div>
-        <label htmlFor="bezirk" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.bezirk.label')} <span className="text-red-500">*</span>
-        </label>
-        <select
-          id="bezirk"
-          value={daten.bezirk}
-          onChange={(e) => onChange('bezirk', e.target.value)}
-          className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-          required
-        >
-          <option value="">Bitte wählen</option>
-          {Array.from({ length: 23 }, (_, i) => i + 1).map(bezirk => (
-            <option key={bezirk} value={bezirk.toString()}>
-              {bezirk}. Bezirk
-            </option>
-          ))}
-        </select>
-      </div>
+      <AutoGrid min="18rem" className="gap-y-6">
+        {/* Bezirk */}
+        <div className="min-w-0">
+          <label htmlFor="bezirk" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.bezirk.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <select
+            id="bezirk"
+            value={daten.bezirk}
+            onChange={(e) => onChange('bezirk', e.target.value)}
+            className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            required
+          >
+            <option value="">Bitte wählen</option>
+            {Array.from({ length: 23 }, (_, i) => i + 1).map(bezirk => (
+              <option key={bezirk} value={bezirk.toString()}>
+                {bezirk}. Bezirk
+              </option>
+            ))}
+          </select>
+        </div>
 
-      {/* Straße */}
-      <div>
-        <label htmlFor="strasse" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.strasse.label')} <span className="text-red-500">*</span>
-        </label>
-        <input
-          id="strasse"
-          type="text"
-          value={daten.strasse}
-          onChange={(e) => onChange('strasse', e.target.value)}
-          placeholder={t('felder.strasse.platzhalter')}
-          className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-          required
-        />
-      </div>
+        {/* Straße */}
+        <div className="min-w-0">
+          <label htmlFor="strasse" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.strasse.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <input
+            id="strasse"
+            type="text"
+            value={daten.strasse}
+            onChange={(e) => onChange('strasse', e.target.value)}
+            placeholder={t('felder.strasse.platzhalter')}
+            className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            required
+          />
+        </div>
 
-      {/* Grundstück */}
-      <div>
-        <label htmlFor="grundstueck" className="block text-sm font-semibold text-gray-700 mb-2">
-          {t('felder.grundstueck.label')} <span className="text-red-500">*</span>
-        </label>
-        <input
-          id="grundstueck"
-          type="text"
-          value={daten.grundstueck}
-          onChange={(e) => onChange('grundstueck', e.target.value)}
-          placeholder={t('felder.grundstueck.platzhalter')}
-          className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
-          required
-        />
-        <p className="mt-1.5 text-sm text-gray-600">
-          {t('felder.grundstueck.hilfe')}
-        </p>
-      </div>
+        {/* Grundstück */}
+        <div className="min-w-0">
+          <label htmlFor="grundstueck" className="block text-sm font-semibold text-gray-700 mb-2">
+            <BreakText>
+              {t('felder.grundstueck.label')} <span className="text-red-500">*</span>
+            </BreakText>
+          </label>
+          <input
+            id="grundstueck"
+            type="text"
+            value={daten.grundstueck}
+            onChange={(e) => onChange('grundstueck', e.target.value)}
+            placeholder={t('felder.grundstueck.platzhalter')}
+            className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all"
+            required
+          />
+          <BreakText className="mt-1.5 block text-sm text-gray-600">
+            {t('felder.grundstueck.hilfe')}
+          </BreakText>
+        </div>
+      </AutoGrid>
 
       {/* Adressen-Checker Ergebnisse */}
       {showAddressChecker && daten.addressCheckerData && (
@@ -194,21 +210,25 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
               ) : (
                 <CheckCircle className="w-6 h-6 text-green-600" />
               )}
-              <div>
-                <h4 className="font-bold text-gray-900">{t('umgebungsanalyse.titel')}</h4>
-                <p className="text-sm text-gray-700">
+              <div className="min-w-0">
+                <h4 className="font-bold text-gray-900 min-w-0">
+                  <BreakText className="block">{t('umgebungsanalyse.titel')}</BreakText>
+                </h4>
+                <BreakText className="block text-sm text-gray-700">
                   {t('umgebungsanalyse.risikobewertung')}: <span className="font-semibold">
                     {daten.addressCheckerData.riskAssessment.overallRisk === 'high' ? t('umgebungsanalyse.risiko.hoch') :
                      daten.addressCheckerData.riskAssessment.overallRisk === 'medium' ? t('umgebungsanalyse.risiko.mittel') : t('umgebungsanalyse.risiko.gering')}
                   </span>
-                </p>
+                </BreakText>
               </div>
             </div>
           </div>
 
           {/* Karte */}
           <div>
-            <h4 className="font-bold text-gray-900 mb-3">{t('umgebungsanalyse.kartenTitel')}</h4>
+            <h4 className="font-bold text-gray-900 mb-3 min-w-0">
+              <BreakText className="block">{t('umgebungsanalyse.kartenTitel')}</BreakText>
+            </h4>
             <ViennaGISMap
               address={daten.addressCheckerData.address}
               pois={daten.addressCheckerData.pois}
@@ -218,8 +238,10 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
           {/* POI-Liste */}
           {daten.addressCheckerData.pois.length > 0 && (
             <div>
-              <h4 className="font-bold text-gray-900 mb-3">
-                {t('umgebungsanalyse.poisTitel')} ({daten.addressCheckerData.pois.length})
+              <h4 className="font-bold text-gray-900 mb-3 min-w-0">
+                <BreakText className="block">
+                  {t('umgebungsanalyse.poisTitel')} ({daten.addressCheckerData.pois.length})
+                </BreakText>
               </h4>
               <POIList pois={daten.addressCheckerData.pois} />
             </div>
@@ -228,10 +250,14 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
           {/* Warnungen */}
           {daten.addressCheckerData.riskAssessment.warnings.length > 0 && (
             <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded-r-lg">
-              <h4 className="font-bold text-amber-900 mb-2">{t('umgebungsanalyse.warnungenTitel')}</h4>
+              <h4 className="font-bold text-amber-900 mb-2 min-w-0">
+                <BreakText className="block">{t('umgebungsanalyse.warnungenTitel')}</BreakText>
+              </h4>
               <ul className="list-disc list-inside space-y-1 text-sm text-amber-900">
                 {daten.addressCheckerData.riskAssessment.warnings.map((warning, i) => (
-                  <li key={i}>{warning}</li>
+                  <li key={i} className="min-w-0">
+                    <BreakText>{warning}</BreakText>
+                  </li>
                 ))}
               </ul>
             </div>
@@ -240,10 +266,14 @@ export default function SchrittStandort({ daten, onChange }: SchrittStandortProp
           {/* Empfehlungen */}
           {daten.addressCheckerData.riskAssessment.recommendations.length > 0 && (
             <div className="bg-blue-50 border-l-4 border-blue-500 p-4 rounded-r-lg">
-              <h4 className="font-bold text-blue-900 mb-2">{t('umgebungsanalyse.empfehlungenTitel')}</h4>
+              <h4 className="font-bold text-blue-900 mb-2 min-w-0">
+                <BreakText className="block">{t('umgebungsanalyse.empfehlungenTitel')}</BreakText>
+              </h4>
               <ul className="list-disc list-inside space-y-1 text-sm text-blue-900">
                 {daten.addressCheckerData.riskAssessment.recommendations.map((rec, i) => (
-                  <li key={i}>{rec}</li>
+                  <li key={i} className="min-w-0">
+                    <BreakText>{rec}</BreakText>
+                  </li>
                 ))}
               </ul>
             </div>

--- a/app/components/FormularAssistent/schritte/SchrittZusammenfassung.tsx
+++ b/app/components/FormularAssistent/schritte/SchrittZusammenfassung.tsx
@@ -2,6 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 import { CheckCircle, Edit, User, MapPin, FileText, Ruler, AlertTriangle } from 'lucide-react';
+import AutoGrid from '@/components/ui/AutoGrid';
+import BreakText from '@/components/ui/BreakText';
 import type { FormularDaten } from '../types';
 
 interface SchrittZusammenfassungProps {
@@ -20,68 +22,72 @@ export default function SchrittZusammenfassung({ daten, onZurueck }: SchrittZusa
           <CheckCircle className="w-6 h-6 text-green-600" />
         </div>
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{t('titel')}</h2>
-          <p className="text-gray-600">{t('beschreibung')}</p>
+          <h2 className="text-2xl font-bold text-gray-900 min-w-0">
+            <BreakText className="block">{t('titel')}</BreakText>
+          </h2>
+          <BreakText className="block text-gray-600">{t('beschreibung')}</BreakText>
         </div>
       </div>
 
       {/* Antragsteller */}
       <div className="bg-white border-2 border-gray-200 rounded-lg p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between mb-4 gap-3">
+          <div className="flex items-center gap-2 min-w-0">
             <User className="w-5 h-5 text-blue-600" />
-            <h3 className="font-bold text-gray-900">Antragsteller</h3>
+            <h3 className="font-bold text-gray-900 min-w-0">
+              <BreakText className="block">Antragsteller</BreakText>
+            </h3>
           </div>
           <button
             onClick={onZurueck}
             className="text-blue-600 hover:text-blue-700 text-sm font-medium flex items-center gap-1"
           >
             <Edit className="w-4 h-4" />
-            Bearbeiten
+            <BreakText>Bearbeiten</BreakText>
           </button>
         </div>
-        <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-          <div>
-            <dt className="font-semibold text-gray-700">Name und Anschrift</dt>
-            <dd className="text-gray-600 mt-1">{daten.name || '-'}</dd>
+        <AutoGrid min="18rem" className="gap-y-4 text-sm">
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Name und Anschrift</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.name || '-'}</BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Kontaktperson</dt>
-            <dd className="text-gray-600 mt-1">{daten.kontaktperson || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Kontaktperson</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.kontaktperson || '-'}</BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Telefon</dt>
-            <dd className="text-gray-600 mt-1">{daten.telefon || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Telefon</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.telefon || '-'}</BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">E-Mail</dt>
-            <dd className="text-gray-600 mt-1">{daten.email || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">E-Mail</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.email || '-'}</BreakText>
           </div>
-        </dl>
+        </AutoGrid>
       </div>
 
       {/* Standort */}
       <div className="bg-white border-2 border-gray-200 rounded-lg p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <MapPin className="w-5 h-5 text-blue-600" />
-            <h3 className="font-bold text-gray-900">Standort</h3>
-          </div>
+        <div className="flex items-center gap-2 mb-4 min-w-0">
+          <MapPin className="w-5 h-5 text-blue-600" />
+          <h3 className="font-bold text-gray-900 min-w-0">
+            <BreakText className="block">Standort</BreakText>
+          </h3>
         </div>
-        <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-          <div>
-            <dt className="font-semibold text-gray-700">Bezirk</dt>
-            <dd className="text-gray-600 mt-1">{daten.bezirk ? `${daten.bezirk}. Bezirk` : '-'}</dd>
+        <AutoGrid min="18rem" className="gap-y-4 text-sm">
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Bezirk</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.bezirk ? `${daten.bezirk}. Bezirk` : '-'}</BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Straße, Hausnummer</dt>
-            <dd className="text-gray-600 mt-1">{daten.strasse || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Straße, Hausnummer</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.strasse || '-'}</BreakText>
           </div>
-          <div className="md:col-span-2">
-            <dt className="font-semibold text-gray-700">Grundstücksnummer</dt>
-            <dd className="text-gray-600 mt-1">{daten.grundstueck || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Grundstücksnummer</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.grundstueck || '-'}</BreakText>
           </div>
-        </dl>
+        </AutoGrid>
 
         {/* Risikobewertung falls vorhanden */}
         {daten.addressCheckerData && (
@@ -94,12 +100,12 @@ export default function SchrittZusammenfassung({ daten, onZurueck }: SchrittZusa
                 : 'bg-green-50 text-green-900'
             }`}>
               <AlertTriangle className="w-5 h-5 flex-shrink-0" />
-              <div className="text-sm">
+              <BreakText className="text-sm">
                 <span className="font-semibold">Umgebungsanalyse:</span>{' '}
                 {daten.addressCheckerData.pois.length} kritische Einrichtung(en) im Umkreis • Risiko:{' '}
                 {daten.addressCheckerData.riskAssessment.overallRisk === 'high' ? 'Hoch' :
                  daten.addressCheckerData.riskAssessment.overallRisk === 'medium' ? 'Mittel' : 'Gering'}
-              </div>
+              </BreakText>
             </div>
           </div>
         )}
@@ -107,68 +113,68 @@ export default function SchrittZusammenfassung({ daten, onZurueck }: SchrittZusa
 
       {/* Antragstyp */}
       <div className="bg-white border-2 border-gray-200 rounded-lg p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <FileText className="w-5 h-5 text-blue-600" />
-            <h3 className="font-bold text-gray-900">Antragstyp</h3>
-          </div>
+        <div className="flex items-center gap-2 mb-4 min-w-0">
+          <FileText className="w-5 h-5 text-blue-600" />
+          <h3 className="font-bold text-gray-900 min-w-0">
+            <BreakText className="block">Antragstyp</BreakText>
+          </h3>
         </div>
-        <dl className="space-y-4 text-sm">
-          <div>
-            <dt className="font-semibold text-gray-700">Art des Antrags</dt>
-            <dd className="text-gray-600 mt-1">
+        <div className="space-y-4 text-sm">
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Art des Antrags</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">
               {daten.typ === 'neu' ? 'Errichtung und Betrieb einer neuen Betriebsanlage' :
                daten.typ === 'aenderung' ? 'Änderung einer bestehenden genehmigten Betriebsanlage' : '-'}
-            </dd>
+            </BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Art der Anlage</dt>
-            <dd className="text-gray-600 mt-1">{daten.art_der_anlage || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Art der Anlage</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">{daten.art_der_anlage || '-'}</BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Anlagenteile und Tätigkeiten</dt>
-            <dd className="text-gray-600 mt-1 whitespace-pre-wrap">{daten.anlagenteile || '-'}</dd>
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Anlagenteile und Tätigkeiten</BreakText>
+            <BreakText className="text-gray-600 mt-1 block whitespace-pre-wrap">{daten.anlagenteile || '-'}</BreakText>
           </div>
-        </dl>
+        </div>
       </div>
 
       {/* Flächen */}
       <div className="bg-white border-2 border-gray-200 rounded-lg p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <Ruler className="w-5 h-5 text-blue-600" />
-            <h3 className="font-bold text-gray-900">Betriebsflächen</h3>
-          </div>
+        <div className="flex items-center gap-2 mb-4 min-w-0">
+          <Ruler className="w-5 h-5 text-blue-600" />
+          <h3 className="font-bold text-gray-900 min-w-0">
+            <BreakText className="block">Betriebsflächen</BreakText>
+          </h3>
         </div>
-        <dl className="space-y-4 text-sm">
-          <div>
-            <dt className="font-semibold text-gray-700">Beschreibung der Flächen</dt>
-            <dd className="text-gray-600 mt-1 whitespace-pre-wrap font-mono text-xs bg-gray-50 p-3 rounded">
+        <div className="space-y-4 text-sm">
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Beschreibung der Flächen</BreakText>
+            <BreakText className="text-gray-600 mt-1 block whitespace-pre-wrap font-mono text-xs bg-gray-50 p-3 rounded">
               {daten.flaechen_beschreibung || '-'}
-            </dd>
+            </BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Gesamte Fläche</dt>
-            <dd className="text-gray-600 mt-1">
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Gesamte Fläche</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">
               {daten.gesamtflaeche ? `${daten.gesamtflaeche} m²` : '-'}
-            </dd>
+            </BreakText>
           </div>
-          <div>
-            <dt className="font-semibold text-gray-700">Elektrische Anschlussleistung</dt>
-            <dd className="text-gray-600 mt-1">
+          <div className="min-w-0">
+            <BreakText className="font-semibold text-gray-700 block">Elektrische Anschlussleistung</BreakText>
+            <BreakText className="text-gray-600 mt-1 block">
               {daten.anschlussleistung === 'unter300' ? 'Unter 300 Kilowatt (vereinfachtes Verfahren möglich)' :
                daten.anschlussleistung === 'ueber300' ? 'Über 300 Kilowatt (normales Verfahren erforderlich)' :
                daten.anschlussleistung === 'keine' ? 'Keine Maschinen oder Geräte vorhanden' : '-'}
-            </dd>
+            </BreakText>
           </div>
-        </dl>
+        </div>
       </div>
 
       {/* Hinweis */}
       <div className="bg-blue-50 border-l-4 border-blue-500 p-4 rounded-r-lg">
-        <p className="text-sm text-blue-900">
+        <BreakText className="text-sm text-blue-900 block">
           💡 <strong>Tipp:</strong> Überprüfen Sie alle Angaben sorgfältig. Sie können jederzeit zurück zu den einzelnen Schritten gehen, um Änderungen vorzunehmen. Mit Klick auf &quot;PDF erstellen & herunterladen&quot; wird das ausgefüllte Formular als PDF generiert.
-        </p>
+        </BreakText>
       </div>
     </div>
   );

--- a/app/components/HeaderNav.tsx
+++ b/app/components/HeaderNav.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import NavLink from '../components/NavLink';
+import BreakText from '@/components/ui/BreakText';
 
 export default function HeaderNav({ locale }: { locale: string }) {
     const [open, setOpen] = useState(false);
@@ -13,29 +14,38 @@ export default function HeaderNav({ locale }: { locale: string }) {
         <nav className="site-nav sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
             <div className="site-container site-nav__inner mx-auto max-w-screen-xl w-full px-4">
                 {/* Head Row */}
-                <div className="flex h-14 items-center justify-between">
+                <div className="flex h-14 items-center justify-between gap-3 md:gap-6">
                     {/* Brand: Logo + Titel (kurz auf Mobile, voll ab md) */}
                     <Link href={`/${locale}`} className="site-brand flex items-center gap-2 min-w-0" aria-label="Betriebsanlagen Check Startseite">
-                        <span className="site-brand__mark">
-                            {/* verwende dein neues Icon */}
-                            <Image src="/icon.svg" alt="Logo" width={28} height={28} priority />
-                        </span>
-                        <span className="font-semibold text-slate-900 truncate sm:max-w-[12rem] md:max-w-none">
-                            <span className="md:hidden">Betriebsanlagen</span>
-                            <span className="hidden md:inline">Betriebsanlagen Check</span>
-                        </span>
+                        <div className="flex items-center gap-2 min-w-0">
+                            <span className="site-brand__mark">
+                                {/* verwende dein neues Icon */}
+                                <Image src="/icon.svg" alt="Logo" width={28} height={28} priority />
+                            </span>
+                            <BreakText className="hidden md:inline font-semibold text-slate-900">
+                                Betriebsanlagen Check
+                            </BreakText>
+                        </div>
                     </Link>
 
                     {/* Desktop-Navigation */}
-                    <div className="hidden md:flex site-nav__links items-center gap-6">
-                        <NavLink href={`/${locale}/adressen-check`}>Adressen-Check</NavLink>
-                        <NavLink href={`/${locale}/formular-assistent`}>Formular-Assistent</NavLink>
-                        <NavLink href={`/${locale}/dokumente`} activeMatch={[`/${locale}/documents`]}>Dokumente</NavLink>
-                        <NavLink href={`/${locale}/faq`}>FAQ</NavLink>
+                    <div className="hidden md:flex site-nav__links flex-wrap items-center gap-x-6 gap-y-2 min-w-0">
+                        <NavLink href={`/${locale}/adressen-check`}>
+                            <BreakText className="truncate md:truncate-0">Adressen-Check</BreakText>
+                        </NavLink>
+                        <NavLink href={`/${locale}/formular-assistent`}>
+                            <BreakText className="truncate md:truncate-0">Formular-Assistent</BreakText>
+                        </NavLink>
+                        <NavLink href={`/${locale}/dokumente`} activeMatch={[`/${locale}/documents`]}>
+                            <BreakText className="truncate md:truncate-0">Dokumente</BreakText>
+                        </NavLink>
+                        <NavLink href={`/${locale}/faq`}>
+                            <BreakText className="truncate md:truncate-0">FAQ</BreakText>
+                        </NavLink>
                     </div>
 
                     {/* Language + Mobile Toggle */}
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
                         <LanguageSwitcher />
                         <button
                             className="md:hidden inline-flex items-center justify-center rounded-md p-2"

--- a/components/ui/AutoGrid.tsx
+++ b/components/ui/AutoGrid.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, type CSSProperties } from "react";
+
+export default function AutoGrid({
+  children,
+  className = "",
+  min = "16rem",
+  gap = "1rem",
+}: {
+  children: ReactNode;
+  className?: string;
+  min?: string;
+  gap?: string;
+}) {
+  const style = {
+    gap,
+    "--min": min,
+  } as CSSProperties & Record<string, string>;
+
+  return (
+    <div
+      className={`grid [grid-template-columns:repeat(auto-fit,minmax(var(--min),1fr))] gap-x-4 gap-y-4 ${className}`}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/ui/BreakText.tsx
+++ b/components/ui/BreakText.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+export default function BreakText({
+  className = "",
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span className={`min-w-0 break-words [overflow-wrap:anywhere] [hyphens:auto] ${className}`}>
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add BreakText and AutoGrid helper components to centralize hyphenation, wrapping, and responsive grid behavior
- apply responsive text handling to the header navigation, home page cards, and address checker flows to prevent overflow on narrow screens
- refactor form steps in the FormularAssistent to use auto-fit grids and BreakText for better stacking and word wrapping

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690d24aab43c832b90d52df905f2313a